### PR TITLE
Ask user for sub-circuits of unknown models

### DIFF
--- a/src/kicadtoNgspice/KicadtoNgspice.py
+++ b/src/kicadtoNgspice/KicadtoNgspice.py
@@ -106,13 +106,20 @@ class MainWindow(QtGui.QWidget):
         Also if the two model of same name is present under modelParamXML directory
         """           
         if unknownModelList:
-            print "Unknown Model List is : ",unknownModelList
-            self.msg = QtGui.QErrorMessage()
-            self.content = "Your schematic contain unknown model "+', '.join(unknownModelList)
-            self.msg.showMessage(self.content)
-            self.msg.setWindowTitle("Unknown Models")
+            for comp_line in kicadNetlist:
+                if any(s.upper() in comp_line.upper() for s in unknownModelList):
+                    schematicInfo.append("X" + comp_line.strip())
+                    continue
+
+            unknownModelList = []
+            print schematicInfo
+
+            self.messageBox = QtGui.QMessageBox()
+            self.messageBox.setText("You will need to add sub circuits for several components!")
+            self.messageBox.setIcon(QtGui.QMessageBox.Information)
+            self.messageBox.exec_()
             
-        elif multipleModelList:
+        if multipleModelList:
             self.msg = QtGui.QErrorMessage()
             self.mcontent = "Look like you have duplicate model in modelParamXML directory "+', '.join(multipleModelList[0])
             self.msg.showMessage(self.mcontent)

--- a/src/kicadtoNgspice/SubcircuitTab.py
+++ b/src/kicadtoNgspice/SubcircuitTab.py
@@ -48,7 +48,7 @@ class SubcircuitTab(QtGui.QWidget):
         
         for eachline in schematicInfo:
             words = eachline.split()
-            if eachline[0] == 'x':
+            if eachline[0].lower() == 'x':
                 print "Subcircuit : Words",words[0]
                 self.obj_trac.subcircuitList[project_name+words[0]] = words
                 self.subcircuit_dict_beg[words[0]] = self.count


### PR DESCRIPTION
Earlier, eSim used to pop an error mentioning that the netlist contains an unknown model. This new addition lets the user choose sub-circuits for all unknown models.