### PR TITLE
Resolves #93

### DIFF
--- a/src/frontEnd/Application.py
+++ b/src/frontEnd/Application.py
@@ -30,7 +30,7 @@ import time
 from PyQt4.Qt import QSize
 import sys
 import os
-
+import time
 
 # Its our main window of application.
 class Application(QtGui.QMainWindow):
@@ -324,7 +324,33 @@ class Application(QtGui.QMainWindow):
 
         if self.projDir is not None:
             self.obj_Mainview.obj_dockarea.ngspiceEditor(self.projDir)
-            time.sleep(2)  # Need permanent solution
+
+            # Fail Safe, to never go in infinte loop -
+            '''
+            t_end = time.time() + 5*60
+            while(time.time() < t_end):
+                pass
+            '''
+            # Run the while loop for a max of 300 seconds (5 minutes)
+
+            if("plot_data_i.txt" in os.listdir(self.projDir)):
+                lastModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
+                newModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
+
+                while(newModificationTime == lastModificationTime):
+                    newModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
+                    # Poll for data every 0.2 seconds, so system doesn't crash
+                    time.sleep(0.2)
+                
+            else:
+                files = os.listdir(self.projDir)
+                while("plot_data_i.txt" not in files):
+                    files = os.listdir(self.projDir)
+                    # Poll for data every 0.2 seconds, so system doesn't crash
+                    time.sleep(0.2)
+
+
+            # time.sleep(2)  # Need permanent solution
             # Calling Python Plotting
 
             try:

--- a/src/frontEnd/Application.py
+++ b/src/frontEnd/Application.py
@@ -30,9 +30,10 @@ import time
 from PyQt4.Qt import QSize
 import sys
 import os
-import time
 
 # Its our main window of application.
+
+
 class Application(QtGui.QMainWindow):
     """This class initializes all objects used in this file(Application.py)."""
     global project_name
@@ -325,34 +326,23 @@ class Application(QtGui.QMainWindow):
         if self.projDir is not None:
             self.obj_Mainview.obj_dockarea.ngspiceEditor(self.projDir)
 
-            # Fail Safe, to never go in infinte loop -
-            '''
-            t_end = time.time() + 5*60
-            while(time.time() < t_end):
-                pass
-            '''
-            # Run the while loop for a max of 300 seconds (5 minutes)
+            currTime = time.time()
+            count = 0
+            while True:
+                try:
+                    st = os.stat(os.path.join(self.projDir, "plot_data_i.txt"))
+                    if st.st_mtime >= currTime:
+                        break
+                except Exception:
+                    pass
+                time.sleep(0.2)
 
-            if("plot_data_i.txt" in os.listdir(self.projDir)):
-                lastModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
-                newModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
+                # Fail Safe ===>
+                count += 1
+                if count >= 100:
+                    raise Exception("ngspice taking too long, check netlist file")
 
-                while(newModificationTime == lastModificationTime):
-                    newModificationTime = os.path.getmtime(self.projDir+"/plot_data_i.txt")
-                    # Poll for data every 0.2 seconds, so system doesn't crash
-                    time.sleep(0.2)
-                
-            else:
-                files = os.listdir(self.projDir)
-                while("plot_data_i.txt" not in files):
-                    files = os.listdir(self.projDir)
-                    # Poll for data every 0.2 seconds, so system doesn't crash
-                    time.sleep(0.2)
-
-
-            # time.sleep(2)  # Need permanent solution
             # Calling Python Plotting
-
             try:
                 self.obj_Mainview.obj_dockarea.plottingEditor()
             except Exception as e:


### PR DESCRIPTION
**Resolves** #93
- If `plot` files present, polls their modification time every 0.2 seconds
- If `plot` files not present, checks whether `plot` files created in project directory, polled every 0.2 seconds
- Fail safe commented for now, since `.cir.out` files will always be writing to `plot` files. _(Can be applied whenever necessary)_
- Other possible solutions include [Synchronous process API](https://doc.qt.io/qt-5/qprocess.html#synchronous-process-api) from `QProcess`, but here the ngspice window needs to be completely closed, which isn't what is expected as per the User Manual.
- We require both `ngspice` and `python plotting` windows active