### PR TITLE
Fixed eSim Crash Issue in Windows 8 OS

### DIFF
--- a/Windows/README.md
+++ b/Windows/README.md
@@ -35,7 +35,7 @@ It contains all the documentation for making eSim executable (using PyInstaller)
 			$ pip install matplotlib==3.0.3
 			$ pip install tornado
 			$ pip install setuptools
-			$ pip install PyQt5
+			$ pip install PyQt5==5.9.2
 			$ pip install pypiwin32
 		
 7. Test whether only eSim dependencies are available or not:

--- a/Windows/esim-setup-script.nsi
+++ b/Windows/esim-setup-script.nsi
@@ -1,6 +1,7 @@
 ;NSIS Modern User Interface
 ;Start Menu Folder Selection Example Script
 ;Modified by Fahim Khan, Saurabh Bansode, Rahul Paknikar - 01_03_2020
+;Modified by Manasi Yadav, Sumanto Kar - 17_08_2021
 ;Made by eSim Team, FOSSEE, IIT Bombay
 
 ;--------------------------------
@@ -190,6 +191,7 @@ Section -NgspiceSim
   FileOpen $0  "$PROFILE\.esim\config.ini" w
   FileWrite $0 `[eSim]$\n`
   FileWrite $0 `eSim_HOME = $INSTDIR\eSim$\n`
+  FileWrite $0 `eSim = %(eSim_HOME)s\eSim.bat$\n`
   FileWrite $0 `LICENSE = %(eSim_HOME)s\LICENSE.rtf$\n`
   FileWrite $0 `KicadLib = %(eSim_HOME)s\library\kicadLibrary.zip$\n`
   FileWrite $0 `IMAGES = %(eSim_HOME)s\images$\n`


### PR DESCRIPTION
Specified the version of PyQt5 to be installed.

The Bluetooth API module implemented in the existing version of PyQt5 is not supported by the Windows 8 OS, due to which eSim 2.1 crashes in Windows 8. To fix this, PyQt5 is downgraded to a version lower than 5.10 i.e. 5.9.2.