### PR TITLE
Updated Readme.md to Specify PyQt5 version

### DIFF
--- a/Windows/README.md
+++ b/Windows/README.md
@@ -35,7 +35,7 @@ It contains all the documentation for making eSim executable (using PyInstaller)
 			$ pip install matplotlib==3.0.3
 			$ pip install tornado
 			$ pip install setuptools
-			$ pip install PyQt5
+			$ pip install PyQt5==5.9.2
 			$ pip install pypiwin32
 		
 7. Test whether only eSim dependencies are available or not:


### PR DESCRIPTION
Modified by Manasi Yadav, Sumanto Kar on 17.08.2021

Specified the version of PyQt5 to be installed.

The Bluetooth API module implemented into the existing version of PyQt5 is not supported by the Windows 8 OS, due to which eSim 2.1 crashes in Windows 8. To fix this, PyQt5 is downgraded to a version lower than 5.10 i.e. 5.9.2.