### PR TITLE
Replaced eSim_AC by AC

### DIFF
--- a/library/kicadLibrary/kicad_eSim-Library/eSim_Sources.lib
+++ b/library/kicadLibrary/kicad_eSim-Library/eSim_Sources.lib
@@ -1,7 +1,7 @@
 EESchema-LIBRARY Version 2.3
 #encoding utf-8
 #
-# eSim_AC
+# AC
 #
 DEF eSim_AC v 0 40 Y Y 1 F N
 F0 "v" -200 100 60 H V C CNN


### PR DESCRIPTION
### Purpose

The AC source doesn't appear in the KiCAD_Ngspice Conversion Tab.

### Approach

Due to the prefix "eSim_", the AC source doesn't appear in the KiCAD_Ngspice Conversion Tab hence the prefix is removed.
