### PR TITLE
Replaced eSim_AC by AC in DEF and  F1

### DIFF
--- a/library/kicadLibrary/kicad_eSim-Library/eSim_Sources.lib
+++ b/library/kicadLibrary/kicad_eSim-Library/eSim_Sources.lib
@@ -3,9 +3,9 @@ EESchema-LIBRARY Version 2.3
 #
 # AC
 #
-DEF eSim_AC v 0 40 Y Y 1 F N
+DEF AC v 0 40 Y Y 1 F N
 F0 "v" -200 100 60 H V C CNN
-F1 "eSim_AC" -200 -50 60 H V C CNN
+F1 "AC" -200 -50 60 H V C CNN
 F2 "R1" -300 0 60 H V C CNN
 F3 "" 0 0 60 H V C CNN
 $FPLIST


### PR DESCRIPTION
Purpose
The AC source doesn't appear in the KiCAD-Ngspice Conversion Tab.

Approach
Due to the prefix "eSim_", the AC source doesn't appear in the KiCAD-Ngspice Conversion Tab hence the prefix is removed.