### PR TITLE
Fixed path_name undefined and out of bound index errors

### DIFF
--- a/src/kicadtoNgspice/Convert.py
+++ b/src/kicadtoNgspice/Convert.py
@@ -554,7 +554,7 @@ class Convert:
                         print(tempStr)
                         includeLine.append(
                             ".lib \"" + tempStr[0] + "\" " + tempStr[1])
-                        deviceLine[index] = ''
+                        deviceLine[index] = '*scmode'
                         # words.append(completeLibPath)
                         # deviceLine[index] = words
 

--- a/src/kicadtoNgspice/DeviceModel.py
+++ b/src/kicadtoNgspice/DeviceModel.py
@@ -159,11 +159,13 @@ sky130_fd_pr/models/sky130.lib.spice")
         self.entry_var[self.count].setText("")
         self.entry_var[self.count].setMaximumWidth(150)
         self.entry_var[self.count].setObjectName("%d" % beg)
+        path_name = ''
         for child in self.root:
             if child.tag == "scmode1":
                 if child[1].text:
                     self.entry_var[self.count] \
                         .setText(child[1].text)
+                    path_name = child[0].text
                 else:
                     self.entry_var[self.count].setText("")
 
@@ -223,6 +225,7 @@ sky130_fd_pr/models/sky130.lib.spice")
                 sky130box.setTitle(
                     "Add parameters for " +
                     words[0] + " : " + words[-1])
+                path_name = ''
 
                 # Adding to get sky130 dimension
                 self.parameterLabel[self.count] = QtWidgets.QLabel(
@@ -251,7 +254,7 @@ sky130_fd_pr/models/sky130.lib.spice")
                                 if child[0].text:
                                     self.entry_var[self.count] \
                                         .setText(child[0].text)
-                                    path_name = ""
+                                    path_name = child[0].text
                                 else:
                                     self.entry_var[self.count].setText("")
                                     path_name = ""


### PR DESCRIPTION
### Related Issues

1. Path_name was not defined and referenced due to which there were errors for sky130 components.

2. The list index of deviceLine[] was getting Out of bounds in the Convert.py file for "scmode" device model.


### Approach
1. Defined and initialized path_name as "".

2. Added a comment for "*scmode" to the deviceLine[] list.
