### PR TITLE
Automatic packaging and releasing of an eSim version for Ubuntu OS

### DIFF
--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,7 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo "version=$(echo ${{github.ref_name}} | tr -d "v" -f 2)" >> $GITHUB_ENV
+          echo "version=$(echo ${{github.ref_name}} | tr -d 'v' -f 2)" >> $GITHUB_ENV
           wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.version }}.pdf
 
       - name: Zip the eSim_release folder

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -1,11 +1,9 @@
-#This flow will build the latest docker image, test the OpenFASOC flow in it and if it works, update the readme file and push it to the docker hub for reference
-
 name: Auto release of eSim for Ubuntu OS
 
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'eSim-*' # Push events to matching v*, i.e. eSim-2.2, eSim-2.3 etc
   workflow_dispatch:
 
 
@@ -14,12 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+
 # Create eSim release directory
       - name: Preparing eSim for release
         run: mkdir /home/runner/work/eSim_release
 
-# Steps to prepare nghld.zip 
 
+# Steps to prepare nghld.zip 
       - name: Preparing nghdl for release
         run: mkdir /home/runner/work/nghdl_release
 
@@ -53,8 +52,8 @@ jobs:
           cp nghld.zip /home/runner/work/eSim_release/.
           tree /home/runner/work/
 
-# Steps to prepare eSim release directory
 
+# Steps to prepare eSim release directory
       - name: Checkout FOSSEE/eSim master branch
         uses: actions/checkout@v3
         with:
@@ -82,21 +81,27 @@ jobs:
         run: |
           cp Ubuntu/install-eSim.sh /home/runner/work/eSim_release/.
 
+      # extract the number from the tag to pull the relevant manual from the website
+      - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
+        run: |
+          version=echo ${{github.ref_name}} | tr -d "-" -f 2
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{version}}.pdf
+
       - name: Zip the eSim_release folder
         run: |
           cd /home/runner/work/
           zip -r eSim_release.zip eSim_release/
 
-# Create a release and upload artifact
 
+# Create a release and upload artifact
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: test_tag1
-          release_name: Release test_tag2
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,7 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo "version=$(echo ${{github.ref_name}} | tr -d 'v' -f 2)" >> $GITHUB_ENV
+          echo "version=$(echo ${{github.ref_name}} | cut -d 'v' -f 2)" >> $GITHUB_ENV
           wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.version }}.pdf
 
       - name: Zip the eSim_release folder

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,6 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
+          echo ${{github.ref_name}} 
           echo "VERSION=$(echo ${{github.ref_name}} | cut -d 'v' -f 2)" >> $GITHUB_ENV
           wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.VERSION }}.pdf
 

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -95,11 +95,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: test_tag
-          release_name: Release test_tag
+          tag_name: test_tag1
+          release_name: Release test_tag2
           draft: false
           prerelease: false
-          
+
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,8 +84,8 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo "version=$(echo ${{github.ref_name}} | cut -d 'v' -f 2)" >> $GITHUB_ENV
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.version }}.pdf
+          echo "VERSION=$(echo ${{github.ref_name}} | cut -d 'v' -f 2)" >> $GITHUB_ENV
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.VERSION }}.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -86,8 +86,6 @@ jobs:
         run: |
           cd /home/runner/work/
           zip -r eSim_release.zip eSim_release/
-          ls eSim_release.zip
-          tree -L 3
 
 # Create a release and upload artifact
 
@@ -101,6 +99,7 @@ jobs:
           release_name: Release test_tag
           draft: false
           prerelease: false
+          
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
@@ -108,7 +107,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./eSim_release.zip
+          asset_path: /home/runner/work/eSim_release.zip
           asset_name: eSim_release.zip
           asset_content_type: application/zip
       

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,8 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          # echo $GITHUB_REF_NAME
-          echo "VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)" >> $GITHUB_ENV
+          VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)"
           wget https://static.fossee.in/esim/manuals/eSim_Manual_$VERSION.pdf
 
       - name: Zip the eSim_release folder

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,8 +84,8 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          version=echo ${{github.ref_name}} | tr -d "v" -f 2
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_$version.pdf
+          echo "version=$(echo ${{github.ref_name}} | tr -d "v" -f 2)" >> $GITHUB_ENV
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.version }}.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -1,0 +1,115 @@
+#This flow will build the latest docker image, test the OpenFASOC flow in it and if it works, update the readme file and push it to the docker hub for reference
+
+name: Auto release of eSim for Ubuntu OS
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:
+
+
+jobs:
+  release_eSim:
+    runs-on: ubuntu-latest
+    steps:
+
+# Create eSim release directory
+      - name: Preparing eSim for release
+        run: mkdir /home/runner/work/eSim_release
+
+# Steps to prepare nghld.zip 
+
+      - name: Preparing nghdl for release
+        run: mkdir /home/runner/work/nghdl_release
+
+      - name: Checkout FOSSEE/nghdl installers branch
+        uses: actions/checkout@v3
+        with:
+          repository: FOSSEE/nghdl
+          ref: installers
+      
+      - name: Get required data from the nghld/installers branch
+        run: |
+          cp Ubuntu/ghdl-*.tar.xz /home/runner/work/nghdl_release/.
+          cp Ubuntu/verilator-*.tar.xz /home/runner/work/nghdl_release/.
+          cp Ubuntu/install-nghdl.sh /home/runner/work/nghdl_release/.
+
+      - name: Checkout FOSSEE/nghdl installers branch
+        uses: actions/checkout@v3
+        with:
+          repository: FOSSEE/nghdl
+          ref: master
+
+      - name: Get required data from the nghld/master branch
+        run: |
+          cp -rf ./* /home/runner/work/nghdl_release/.
+          cd /home/runner/work
+          rm -rf nghdl_release/.git* nghdl_release/*.md 
+
+      - name: Compress the nghdl folder and copy it to eSim release folder
+        run: |
+          zip -r nghld.zip . -i nghdl_release/.
+          cp nghld.zip /home/runner/work/eSim_release/.
+          tree /home/runner/work/
+
+# Steps to prepare eSim release directory
+
+      - name: Checkout FOSSEE/eSim master branch
+        uses: actions/checkout@v3
+        with:
+          repository: FOSSEE/eSim
+          ref: master
+
+      - name: Compress the library/kicadLibrary folder
+        run: |
+          tar cfJ kicadLibrary.tar.xz library/kicadLibrary/.
+          cp kicadLibrary.tar.xz /home/runner/work/eSim_release/.
+
+      - name: Copy all the data from eSim/master to eSim_release and delete specific data
+        run: |
+          rm -rf .git* code library/browser/User-Manual/figures
+          rm conf.py setup.py index.rst requirements.txt .travis.yml library/browser/User-Manual/eSim.html
+          cp -rf ./* /home/runner/work/eSim_release/.
+
+      - name: Checkout FOSSEE/eSim installers branch
+        uses: actions/checkout@v3
+        with:
+          repository: FOSSEE/eSim
+          ref: installers
+
+      - name: Copy install-eSim.sh script to the release directory
+        run: |
+          cp Ubuntu/install-eSim.sh /home/runner/work/eSim_release/.
+
+      - name: Zip the eSim_release folder
+        run: |
+          cd /home/runner/work/
+          zip -r eSim_release.zip eSim_release/
+          ls eSim_release.zip
+          tree -L 3
+
+# Create a release and upload artifact
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: test_tag
+          release_name: Release test_tag
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./eSim_release.zip
+          asset_name: eSim_release.zip
+          asset_content_type: application/zip
+      
+

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Zip the eSim_release folder
         run: |
           cd /home/runner/work/
-          zip -r eSim_release.zip eSim_release/
+          zip -r eSim-$VERSION.zip eSim_release/
 
 
 # Create a release and upload artifact
@@ -101,7 +101,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
+          release_name: eSim-$VERSION
           draft: false
           prerelease: false
 
@@ -112,8 +112,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: /home/runner/work/eSim_release.zip
-          asset_name: eSim_release.zip
+          asset_path: /home/runner/work/eSim-$VERSION.zip
+          asset_name: eSim-$VERSION.zip
           asset_content_type: application/zip
-      
-

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,9 +84,9 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo $GITHUB_REF_NAME
-          # echo "VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)" >> $GITHUB_ENV
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_$GITHUB_REF_NAME.pdf
+          # echo $GITHUB_REF_NAME
+          echo "VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)" >> $GITHUB_ENV
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_$VERSION.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,7 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)"
+          VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)
           wget https://static.fossee.in/esim/manuals/eSim_Manual_$VERSION.pdf
 
       - name: Zip the eSim_release folder

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -1,10 +1,17 @@
+# By Sai Charan Lanka (@saicharan0112) : Nov 12, 2022
+# This is the workflow to pack the eSim for Ubuntu OS which follows the steps shown in the installer branch and release the zip file which can be uploaded onto the website
+# Note: 
+# 1. Make sure the eSim manual for the version about to release, already exists in the https://static.fossee.in/esim/manuals/ location. Else the release fails.
+# 2. To trigger this workflow, create and push tags that start with "v".
+# For more info, refer to PR#230 and Issue#211
+
+
 name: Auto release of eSim for Ubuntu OS
 
 on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v2.2, v2.3 etc
-  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
           version=echo ${{github.ref_name}} | tr -d "v" -f 2
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{version}}.pdf
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_$version.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,9 +84,9 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo $GITHUB_REF_TYPE
-          # echo "VERSION=$(echo $GITHUB_REF_TYPE | cut -d 'v' -f 2)" >> $GITHUB_ENV
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_$GITHUB_REF_TYPE.pdf
+          echo $GITHUB_REF_NAME
+          # echo "VERSION=$(echo $GITHUB_REF_NAME | cut -d 'v' -f 2)" >> $GITHUB_ENV
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_$GITHUB_REF_NAME.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -84,9 +84,9 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          echo ${{github.ref_name}} 
-          echo "VERSION=$(echo ${{github.ref_name}} | cut -d 'v' -f 2)" >> $GITHUB_ENV
-          wget https://static.fossee.in/esim/manuals/eSim_Manual_${{ env.VERSION }}.pdf
+          echo $GITHUB_REF_TYPE
+          # echo "VERSION=$(echo $GITHUB_REF_TYPE | cut -d 'v' -f 2)" >> $GITHUB_ENV
+          wget https://static.fossee.in/esim/manuals/eSim_Manual_$GITHUB_REF_TYPE.pdf
 
       - name: Zip the eSim_release folder
         run: |

--- a/.github/workflows/release_ubuntu.yml
+++ b/.github/workflows/release_ubuntu.yml
@@ -3,7 +3,7 @@ name: Auto release of eSim for Ubuntu OS
 on:
   push:
     tags:
-      - 'eSim-*' # Push events to matching v*, i.e. eSim-2.2, eSim-2.3 etc
+      - 'v*' # Push events to matching v*, i.e. v2.2, v2.3 etc
   workflow_dispatch:
 
 
@@ -84,7 +84,7 @@ jobs:
       # extract the number from the tag to pull the relevant manual from the website
       - name: Copy eSim manual which is available at https://static.fossee.in/esim/manuals/
         run: |
-          version=echo ${{github.ref_name}} | tr -d "-" -f 2
+          version=echo ${{github.ref_name}} | tr -d "v" -f 2
           wget https://static.fossee.in/esim/manuals/eSim_Manual_${{version}}.pdf
 
       - name: Zip the eSim_release folder


### PR DESCRIPTION
### Related Issues

https://github.com/FOSSEE/eSim/issues/211

### Purpose

To pack and release the eSim for Ubuntu automatically, whenever a tag which starts with "v" is pushed to the GitHub

### Approach

The workflow follows the instructions given under the Ubuntu section of the installer branch and uses GitHub Actions (GHA) to build and release the package automatically when the relevant tag is created and pushed to the GitHub. See the action with name "Auto release of eSim for Ubuntu OS" for more details on the workflow.

Note: This can be replicated for OS too. 
