### PR TITLE
Changed the Installation path of HDLParse

### DIFF
--- a/Ubuntu/install-eSim.sh
+++ b/Ubuntu/install-eSim.sh
@@ -145,7 +145,7 @@ function installDependency
     pip3 install watchdog
 
     echo "Installing Hdlparse........................"
-    pip3 install hdlparse
+    pip3 install --upgrade https://github.com/hdl/pyhdlparser/tarball/master
 
     echo "Installing Makerchip......................."
     pip3 install makerchip-app


### PR DESCRIPTION
### Related Issues

HDLParse installation throwing the "use_2to3" is invalid for the latest version of Python.

### Purpose

HDLParse installation by pip3.

### Approach

Added the "https://github.com/hdl/pyhdlparser/tarball/master" path for the HDLParse as it contains the newest version of HDLParse supported by the latest Python3.
