### PR TITLE
Made the text in TerminalUi log console selectable

### DIFF
--- a/src/frontEnd/TerminalUi.ui
+++ b/src/frontEnd/TerminalUi.ui
@@ -151,7 +151,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="textInteractionFlags">
-       <set>Qt::NoTextInteraction</set>
+       <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
### Purpose

It was not possible to select the text inside the log that shows up during ngspice simulation.
With this pull request, it would be possible to select and copy lines from the console which displays the log.

### Approach

Just changed the QTextEdit widget's NoTextInteraction property with appropriate properties for selection.
