### PR TITLE
Removed distutils dependency

### DIFF
--- a/src/projManagement/Validation.py
+++ b/src/projManagement/Validation.py
@@ -19,7 +19,7 @@
 
 import os
 import re
-import distutils.spawn
+import shutil
 
 
 class Validation:
@@ -170,7 +170,7 @@ class Validation:
 
     def validateTool(self, toolName):
         """This function check if tool is present in the system."""
-        return distutils.spawn.find_executable(toolName) is not None
+        return shutil.which(toolName) is not None
 
     def validateSubcir(self, projDir, fileName):
         """


### PR DESCRIPTION
shutil can be used in place of distutils .

### Related Issues
<a  href="https://github.com/FOSSEE/eSim/issues/277"> issue 277 <a/>

### Purpose

To completely remove dependency on the deprecated distutils API and ensure the eSim project is aligned with modern Python practices by using shutil.which for executable checks.


### Approach
The distutils library has been deprecated in newer Python versions, and while previous updates have transitioned to using setuptools, one file still incorrectly references distutils. This PR addresses the issue by:

- `Removing distutils Dependency` : Eliminates the use of distutils.spawn.find_executable in the codebase.

- `Updating to Modern Practice`: Replaces distutils checks with shutil.which, which is the recommended approach for checking executable paths.

Installation Script Update:  We can then remove the distutils installation command from the installation script, ensuring there are no lingering dependencies on the deprecated library.

## #Verification:
A search using grep confirmed that distutils is only used in the updated file. Please review and verify if there are any other instances of distutils in the codebase to ensure complete removal.
This change modernizes the codebase and aligns it with current best practices, avoiding issues related to deprecated libraries.
