### PR TITLE
upgrade Install-eSim.sh for Ubuntu 24.04

### DIFF
--- a/Ubuntu/install-eSim.sh
+++ b/Ubuntu/install-eSim.sh
@@ -160,8 +160,8 @@ function installDependency
     echo "Installing Matplotlib......................"
     sudo apt-get install -y python3-matplotlib
 
-    echo "Installing Distutils......................."
-    sudo apt-get install -y python3-distutils
+    echo "Installing Setuptools..................."
+    sudo apt-get install -y python3-setuptools
 
     # Install NgVeri Depedencies
     echo "Installing Pip3............................"


### PR DESCRIPTION
### Purpose

Enable eSim installation on Ubuntu 24.04 .

### Issues resolved
1. use Kicad-8.0 PPA instead of Kicad-6.0
2. use python3-setuptools instead of python3-distutils

Note: the installer should be packaged with nghdl.zip which contains latest commits on the nghdl repo with ghdl version at least 4.1.0.
