### PR TITLE
Enabled Dual Plotting for Simulation

### DIFF
--- a/src/frontEnd/Application.py
+++ b/src/frontEnd/Application.py
@@ -58,6 +58,9 @@ class Application(QtWidgets.QMainWindow):
         # Set slot for simulation end signal to plot simulation data
         self.simulationEndSignal.connect(self.plotSimulationData)
 
+        #the plotFlag
+        self.plotFlag = False
+
         # Creating require Object
         self.obj_workspace = Workspace.Workspace()
         self.obj_Mainview = MainView()
@@ -188,7 +191,7 @@ class Application(QtWidgets.QMainWindow):
             QtGui.QIcon(init_path + 'images/ngspice.png'),
             '<b>Simulate</b>', self
         )
-        self.ngspice.triggered.connect(self.open_ngspice)
+        self.ngspice.triggered.connect(self.plotFlagPopBox)
 
         self.model = QtWidgets.QAction(
             QtGui.QIcon(init_path + 'images/model.png'),
@@ -246,6 +249,27 @@ class Application(QtWidgets.QMainWindow):
         self.lefttoolbar.addAction(self.conToeSim)
         self.lefttoolbar.setOrientation(QtCore.Qt.Vertical)
         self.lefttoolbar.setIconSize(QSize(40, 40))
+
+    def plotFlagPopBox(self):
+        """This function displays a pop-up box with message- Do you want Ngspice plots? and oprions Yes and NO.
+        
+        If the user clicks on Yes, both the NgSpice and python plots are displayed and if No is clicked then only the python plots."""
+
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setWindowTitle("Ngspice Plots")
+        msg_box.setText("Do you want Ngspice plots?")
+        
+        yes_button = msg_box.addButton("Yes", QtWidgets.QMessageBox.YesRole)
+        no_button = msg_box.addButton("No", QtWidgets.QMessageBox.NoRole)
+
+        msg_box.exec_()
+
+        if msg_box.clickedButton() == yes_button:
+            self.plotFlag = True  
+        else:
+            self.plotFlag = False  
+
+        self.open_ngspice()
 
     def closeEvent(self, event):
         '''
@@ -438,7 +462,7 @@ class Application(QtWidgets.QMainWindow):
                 return
 
             self.obj_Mainview.obj_dockarea.ngspiceEditor(
-                projName, ngspiceNetlist, self.simulationEndSignal)
+                projName, ngspiceNetlist, self.simulationEndSignal, self.plotFlag)
 
             self.ngspice.setEnabled(False)
             self.conversion.setEnabled(False)

--- a/src/frontEnd/DockArea.py
+++ b/src/frontEnd/DockArea.py
@@ -127,14 +127,14 @@ class DockArea(QtWidgets.QMainWindow):
             )
         count = count + 1
 
-    def ngspiceEditor(self, projName, netlist, simEndSignal):
+    def ngspiceEditor(self, projName, netlist, simEndSignal, plotFlag):
         """ This function creates widget for Ngspice window."""
         global count
         self.ngspiceWidget = QtWidgets.QWidget()
 
         self.ngspiceLayout = QtWidgets.QVBoxLayout()
         self.ngspiceLayout.addWidget(
-            NgspiceWidget(netlist, simEndSignal)
+            NgspiceWidget(netlist, simEndSignal, plotFlag)
         )
 
         # Adding to main Layout

--- a/src/frontEnd/TerminalUi.py
+++ b/src/frontEnd/TerminalUi.py
@@ -94,6 +94,7 @@ class TerminalUi(QtWidgets.QMainWindow):
     def redoSimulation(self):
         """This function reruns the ngspice simulation
         """
+        self.Flag = "Flase"
         self.cancelSimulationButton.setEnabled(True)
         self.redoSimulationButton.setEnabled(False)
 
@@ -106,6 +107,23 @@ class TerminalUi(QtWidgets.QMainWindow):
 
         self.simulationConsole.setText("")
         self.simulationCancelled = False
+
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setWindowTitle("Ngspice Plots")
+        msg_box.setText("Do you want Ngspice plots?")
+        
+        yes_button = msg_box.addButton("Yes", QtWidgets.QMessageBox.YesRole)
+        no_button = msg_box.addButton("No", QtWidgets.QMessageBox.NoRole)
+
+        msg_box.exec_()
+
+        if msg_box.clickedButton() == yes_button:
+            self.Flag = True 
+        else:
+            self.Flag = False  
+
+        # Emit a custom signal with name plotFlag2 depending upon the Flag
+        self.qProcess.setProperty("plotFlag2", self.Flag)
 
         self.qProcess.start('ngspice', self.args)
 


### PR DESCRIPTION
### Fixes: #296

<!-- Link to the issues that are solved with this PR. -->
https://github.com/FOSSEE/eSim/issues/296

### Purpose
To enable Dual Plotting for Simulation

<!--- Describe the problem or feature. -->
eSim 2.4 automatically plots using Python(Matplotlib) once the netlist is created, while in earlier versions, NgSpice was used. Many users have complained that the Python plotter breaks sometimes or that they don't like it and want to switch back to NgSpice-based plotting.

So, a toggle button was needed that can change which tool is used for plotting. This button should allow the user to select whether to use Python Plotter or NgSpice.

### Approach
1. Created a POP-UP box that appears when users start simulation with message "DO you want NgSpice Plots ? " and the option "Yes " and "NO"
2. If the user clicks on Yes he gets both the python and NgSpice plots.
3. If the user clicks on NO he gets only the python plots.
4. The PR solves this problem and enables dual plotting based on user response.


<!--- ScreenShots -->
[Screencast from 03-24-2025 01:48:15 AM.webm](https://github.com/user-attachments/assets/1dc933d0-b731-4a05-8255-f421c062627f)

