### PR TITLE
Fix pin misalignment in Verilog-generated KiCad symbols in eSim 2.4

### DIFF
--- a/src/maker/createkicad.py
+++ b/src/maker/createkicad.py
@@ -189,9 +189,14 @@ class AutoSchematic:
     def createSym(self):
         '''
             creating the symbol
+            (pins snapped to KiCad-6 grid)
         '''
-        self.dist_port = 2.54         # Distance between two ports (mil)
-        self.inc_size = 2.54          # Increment size of a block (mil)
+        self.grid = 0.635
+        self.dist_port = 4 * self.grid         # Distance between two ports # 100 mil (= 2.54 mm)
+        self.inc_size = self.dist_port      # Increment size of a block (mil)
+        def snap(val):
+                snapped = round(float(val) / self.grid) * self.grid
+                return f"{snapped:.3f}"
         cwd = os.getcwd()
         os.chdir(self.lib_loc)
         print("Changing directory to ", self.lib_loc)
@@ -250,7 +255,7 @@ class AutoSchematic:
 
         draw_pos = \
             [w.replace('comp_name', f"{self.modelname}_0_1") for w in draw_pos]
-        draw_pos[8] = str(float(draw_pos[8]) +           # previously it is (-)
+        draw_pos[8] = snap(float(draw_pos[8]) +           # previously it is (-)
                           float(self.findBlockSize() * self.inc_size))
         draw_pos_rec = draw_pos[8]
 
@@ -265,6 +270,8 @@ class AutoSchematic:
         input_port = input_port.split()
         output_port = self.template["output_port"]
         output_port = output_port.split()
+        input_port[3] = snap(float(input_port[3]))
+        output_port[3] = snap(float(output_port[3]))
         inputs = self.portInfo[0: self.input_length]
         outputs = self.portInfo[self.input_length:]
         inputName = []
@@ -298,7 +305,7 @@ class AutoSchematic:
                 input_port[9] = f"\"{inputName[i]}\""
                 input_port[13] = f"\"{str(i + 1)}\""
                 input_port[4] = \
-                    str(float(input_port[4]) - float(self.dist_port))
+                    snap(float(input_port[4]) - float(self.dist_port))
                 input_list = ' '.join(input_port)
                 port_list.append(input_list)
                 j = j + 1
@@ -307,7 +314,7 @@ class AutoSchematic:
                 output_port[9] = f"\"{outputName[i - inputs]}\""
                 output_port[13] = f"\"{str(i + 1)}\""
                 output_port[4] = \
-                    str(float(output_port[4]) - float(self.dist_port))
+                    snap(float(output_port[4]) - float(self.dist_port))
                 output_list = ' '.join(output_port)
                 port_list.append(output_list)
 


### PR DESCRIPTION
---

### Pin-Alignment Patch for NgVeri Symbols

#### Problem

When eSim moved from KiCad 4 to KiCad 6, verilog generated symbol files didn’t adapt to the updated schematic grid. The old script kept using fixed steps of 2.54 mm for pin placement (50mil), which didn’t align with the new 25 mil grid which used 0.635mm for pin placement in KiCad 6.

This caused pins to sit slightly off-grid, making it hard for wires to connect properly. 

---

#### What's the fix?

* Sets the grid size in the script to 25 mil (0.635 mm), matching KiCad’s default grid.
* Adds a simple snapping function to round pin coordinates to the nearest grid point, so they align perfectly.
* Increases the space between pins to 100 mil (2.54 mm) (4*0.635) so it maintains the legacy look and everything is legible.
* Makes sure both X and Y positions of pins are snapped to the grid before placing them.
* Automatically scales the symbol’s rectangle to match the new pin layout.

---

#### Result

* Tried generating symbols, and verified that all pins line up with the grid.
* Checked in KiCad 6 using both 25 mil and 50 mil grids—wires connect smoothly.
* Tested flipping,mirroring & rotating of symbols to make sure everything stays aligned.

---