### PR TITLE
Fixes issue #262 - Prevented crash when removing lint_off option.

### DIFF
--- a/src/maker/NgVeri.py
+++ b/src/maker/NgVeri.py
@@ -338,14 +338,21 @@ class NgVeri(QtWidgets.QWidget):
             QtWidgets.QMessageBox.Cancel)
 
         if ret == QtWidgets.QMessageBox.Ok:
-            file = open(init_path + "library/tlv/lint_off.txt", 'r')
-            data = file.readlines()
-            file.close()
-
-            data.remove(text + "\n")
-            file = open(init_path + "library/tlv/lint_off.txt", 'w')
-            for item in data:
-                file.write(item)
+            try: 
+                file_path = os.path.join(init_path, "library/tlv/lint_off.txt")
+                with open(file_path, 'r') as file:
+                    data = file.readlines()
+                data = [line for line in data if line.strip() != text]
+                with open(file_path, 'w') as file:
+                    file.writelines(data)
+                    
+            except Exception as e:
+                QtWidgets.QMessageBox.warning(
+                    None,
+                    "Warning",
+                    f"Could not remove lint_off entry '{text}'",
+                    QtWidgets.QMessageBox.Ok
+                )
 
     def add_lint_off(self):
         '''


### PR DESCRIPTION
### Related Issues
Fixes #262 - eSim crashes while using Remove lint_off option

### Purpose
Resolved a runtime crash that occurs when attempting to remove a lint warning entry via the Remove lint_off dropdown in the NgVeri tab. The issue arises when the selected entry does not match any exact line in the lint_off.txt file due to inconsistent line endings or formatting.

### Approach
Modifies the lint_off_edit() function in NgVeri.py to handle (list.remove(x): x not in list) error when removing entries from lint_off.txt. The updated logic uses a try-except block to catch exceptions such as file access errors or missing entries. Instead of crashing the application, a warning message is displayed to the user if the operation fails. Makes the removal process safe and prevents GUI crashes.
