### PR TITLE
Resolved issue #209

### DIFF
--- a/src/frontEnd/ProjectExplorer.py
+++ b/src/frontEnd/ProjectExplorer.py
@@ -28,6 +28,7 @@ class ProjectExplorer(QtWidgets.QWidget):
         self.obj_validation = Validation()
         self.treewidget = QtWidgets.QTreeWidget()
         self.window = QtWidgets.QVBoxLayout()
+        self.fs_watcher = QtCore.QFileSystemWatcher()
         header = QtWidgets.QTreeWidgetItem(["Projects", "path"])
         self.treewidget.setHeaderItem(header)
         self.treewidget.setColumnHidden(1, True)
@@ -68,13 +69,22 @@ class ProjectExplorer(QtWidgets.QWidget):
                     QtWidgets.QTreeWidgetItem(
                         parentnode, [files, os.path.join(parents, files)]
                     )
+                self.fs_watcher.addPath(parents)
         self.window.addWidget(self.treewidget)
+        self.fs_watcher.directoryChanged.connect(self.handleDirectoryChanged)
         self.treewidget.expanded.connect(self.refreshInstant)
         self.treewidget.doubleClicked.connect(self.openProject)
         self.treewidget.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.treewidget.customContextMenuRequested.connect(self.openMenu)
         self.setLayout(self.window)
         self.show()
+    
+    def handleDirectoryChanged(self, path):
+        for i in range(self.treewidget.topLevelItemCount()):
+            item = self.treewidget.topLevelItem(i)
+            if item.text(1) == path and item.isExpanded():
+                index = self.treewidget.indexFromItem(item)
+                self.refreshProject(indexItem=index)
 
     def refreshInstant(self):
         for i in range(self.treewidget.topLevelItemCount()):


### PR DESCRIPTION
### Related Issues

Fixes #209 - Project Explorer not updating the files appropriately

### Purpose

The Project Explorer in eSim does not automatically reflect file deletions made outside the application. Currently, users need to manually refresh the project or collapse and re-expand the project node to see updated files. This results in outdated file listings and poor user experience, especially when working with external tools or file managers.

### Approach

Introduced real-time file monitoring using QFileSystemWatcher. A QFileSystemWatcher instance has been added to monitor all active project directories. When a file is added or removed from a project folder, the associated node in the QTreeWidget is automatically refreshed. The watcher is initialized during the creation of the Project Explorer and dynamically updated as new projects are added or removed.
This ensures that the file tree stays in sync with the actual file system without requiring manual interaction from the user.


