### PR TITLE
eSim Upgradation

### DIFF
--- a/installer/install-eSim-25.04.sh
+++ b/installer/install-eSim-25.04.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+
+config_dir="$HOME/.esim"
+config_file="config.ini"
+eSim_Home=`pwd`
+ngspiceFlag=0
+
+
+###############################################
+# ERROR
+###############################################
+error_exit() {
+    echo -e "\n\nError! Kindly resolve above error(s) and try again."
+    echo -e "\nAborting Installation...\n"
+}
+
+
+###############################################
+# CREATE CONFIG FILE
+###############################################
+createConfigFile() {
+
+    if [ -d $config_dir ]; then
+        rm $config_dir/$config_file && touch $config_dir/$config_file
+    else
+        mkdir $config_dir && touch $config_dir/$config_file
+    fi
+    
+    echo "[eSim]" >> $config_dir/$config_file
+    echo "eSim_HOME = $eSim_Home" >> $config_dir/$config_file
+    echo "LICENSE = %(eSim_HOME)s/LICENSE" >> $config_dir/$config_file
+    echo "KicadLib = %(eSim_HOME)s/library/kicadLibrary.tar.xz" >> $config_dir/$config_file
+    echo "IMAGES = %(eSim_HOME)s/images" >> $config_dir/$config_file
+    echo "VERSION = %(eSim_HOME)s/VERSION" >> $config_dir/$config_file
+    echo "MODELICA_MAP_JSON = %(eSim_HOME)s/library/ngspicetoModelica/Mapping.json" >> $config_dir/$config_file
+}
+
+
+###############################################
+# INSTALL NGHDL
+###############################################
+installNghdl() {
+    echo "Installing NGHDL..."
+    unzip -o nghdl.zip
+    cd nghdl/
+    chmod +x install-nghdl.sh
+
+    trap "" ERR
+    ./install-nghdl.sh --install
+    trap error_exit ERR
+
+    ngspiceFlag=1
+    cd ../
+}
+
+
+###############################################
+# INSTALL SKY130
+###############################################
+installSky130Pdk() {
+    echo "Installing SKY130 PDK..."
+
+    tar -xJf library/sky130_fd_pr.tar.xz
+    sudo rm -rf /usr/share/local/sky130_fd_pr
+
+    echo "Copying SKY130 PDK..."
+    sudo mkdir -p /usr/share/local/
+    sudo mv sky130_fd_pr /usr/share/local/
+    sudo chown -R $USER:$USER /usr/share/local/sky130_fd_pr/
+}
+
+
+###############################################
+# FIXED KICAD INSTALL
+###############################################
+installKicad() {
+
+    ubuntu_version=$(lsb_release -rs)
+
+    echo "Installing KiCad..."
+
+    # If skip flag from main script
+    if [[ "$ESIM_SKIP_KICAD" == "1" ]]; then
+        echo "KiCad installation skipped (handled by main installer)."
+        return
+    fi
+
+    # Ubuntu 24.04 → KiCad 8 PPA
+    if [[ "$ubuntu_version" == "24.04" ]]; then
+        echo "Ubuntu 24.04 detected — installing KiCad 8 via PPA..."
+        sudo add-apt-repository -y ppa:kicad/kicad-8.0-releases
+        sudo apt update
+        sudo apt install -y kicad kicad-footprints kicad-libraries \
+             kicad-symbols kicad-templates
+        return
+    fi
+
+    # Fallback for older versions
+    echo "Installing KiCad from Ubuntu repo..."
+    sudo apt update
+    sudo apt install -y kicad kicad-footprints kicad-libraries \
+         kicad-symbols kicad-templates
+}
+
+
+###############################################
+# INSTALL DEPENDENCIES
+###############################################
+installDependency() {
+
+    set +e
+    trap "" ERR
+
+    echo "Updating apt index..."
+    sudo apt-get update
+    
+    set -e
+    trap error_exit ERR
+    
+    sudo apt install -y python3-virtualenv
+    virtualenv $config_dir/env
+    
+    source $config_dir/env/bin/activate
+
+    pip install --upgrade pip
+    
+    sudo apt-get install -y xterm python3-psutil python3-pyqt5 python3-matplotlib python3-setuptools python3-pip
+
+    pip3 install watchdog
+    pip3 install --upgrade https://github.com/hdl/pyhdlparser/tarball/master
+    pip3 install makerchip-app
+    pip3 install sandpiper-saas
+    pip3 install hdlparse
+    pip3 install matplotlib
+    pip3 install PyQt5
+}
+
+
+###############################################
+# COPY KICAD LIB
+###############################################
+copyKicadLibrary() {
+
+    if [[ "$ESIM_SKIP_KICAD" == "1" ]]; then
+        echo "Skipping KiCad library copy."
+        return
+    fi
+
+    tar -xJf library/kicadLibrary.tar.xz
+
+    mkdir -p ~/.config/kicad/6.0
+
+    cp kicadLibrary/template/sym-lib-table ~/.config/kicad/6.0/
+    sudo cp -r kicadLibrary/eSim-symbols/* /usr/share/kicad/symbols/
+
+    rm -rf kicadLibrary
+    sudo chown -R $USER:$USER /usr/share/kicad/symbols/
+}
+
+
+###############################################
+# CREATE DESKTOP ICON
+###############################################
+createDesktopStartScript() {
+
+    echo '#!/bin/bash' > esim-start.sh
+    echo "cd $eSim_Home/src/frontEnd" >> esim-start.sh
+    echo "source $config_dir/env/bin/activate" >> esim-start.sh
+    echo "python3 Application.py" >> esim-start.sh
+
+    sudo chmod 755 esim-start.sh
+    sudo cp -vp esim-start.sh /usr/bin/esim
+    rm esim-start.sh
+
+    echo "[Desktop Entry]" > esim.desktop
+    echo "Version=1.0" >> esim.desktop
+    echo "Name=eSim" >> esim.desktop
+    echo "Exec=esim %u" >> esim.desktop
+    echo "Terminal=true" >> esim.desktop
+    echo "Type=Application" >> esim.desktop
+    echo "Icon=$config_dir/logo.png" >> esim.desktop
+    echo "Categories=Development;" >> esim.desktop
+
+    sudo chmod 755 esim.desktop
+    sudo cp -vp esim.desktop /usr/share/applications/
+    cp -vp esim.desktop $HOME/Desktop/
+
+    gio set $HOME/Desktop/esim.desktop "metadata::trusted" true
+    chmod a+x $HOME/Desktop/esim.desktop
+    rm esim.desktop
+
+    cp -vp images/logo.png $config_dir
+}
+
+
+###############################################
+# MAIN LOGIC
+###############################################
+
+if [[ $# -ne 1 ]]; then
+    echo "USAGE:"
+    echo "./install-eSim.sh --install"
+    echo "./install-eSim.sh --uninstall"
+    exit 1
+fi
+
+option=$1
+
+
+# ----------- INSTALL MODE --------------
+if [[ $option == "--install" ]]; then
+
+    set -e
+    set -E
+    trap error_exit ERR
+
+    echo -n "Is your internet connection behind proxy? (y/n): "
+    read getProxy
+
+    if [[ $getProxy == "y" || $getProxy == "Y" ]]; then
+        echo "Proxy not recommended — skipping."
+    fi
+
+    createConfigFile
+    installDependency
+    installKicad
+    copyKicadLibrary
+    installNghdl
+    installSky130Pdk
+    createDesktopStartScript
+
+    echo "----------------- eSim Installed Successfully -----------------"
+fi
+

--- a/installer/install-eSim.sh
+++ b/installer/install-eSim.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# ============================================================
+#   Function to detect Ubuntu version
+# ============================================================
+get_ubuntu_version() {
+    VERSION_ID=$(grep "^VERSION_ID" /etc/os-release | cut -d '"' -f 2)
+    FULL_VERSION=$(lsb_release -rs)
+    echo "Detected Ubuntu Version: $FULL_VERSION"
+}
+
+# ============================================================
+#   KiCad fix for Ubuntu 25.04
+# ============================================================
+install_kicad_for_25() {
+    echo ""
+    echo "==============================================="
+    echo "  Ubuntu 25.04 detected — KiCad PPA NOT SUPPORTED"
+    echo "  Installing KiCad from Ubuntu repository..."
+    echo "==============================================="
+    echo ""
+
+    sudo apt update
+    sudo apt install -y kicad kicad-footprints kicad-libraries \
+         kicad-symbols kicad-templates
+
+    echo "KiCad installation complete."
+}
+
+# ============================================================
+#   Function to run proper installer
+# ============================================================
+run_version_script() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-eSim-scripts"
+
+    case $VERSION_ID in
+        "22.04") SCRIPT="$SCRIPT_DIR/install-eSim-23.04.sh" ;;
+        "23.04") SCRIPT="$SCRIPT_DIR/install-eSim-23.04.sh" ;;
+        "24.04") SCRIPT="$SCRIPT_DIR/install-eSim-24.04.sh" ;;
+        "25.04")
+            echo "Ubuntu 25.04 detected — enabling compatibility mode."
+            SCRIPT="$SCRIPT_DIR/install-eSim-24.04.sh"
+            ;;
+        *)
+            echo "Unsupported Ubuntu version: $VERSION_ID ($FULL_VERSION)"
+            exit 1
+            ;;
+    esac
+
+    # Special Fix for KiCad
+    if [[ "$VERSION_ID" == "25.04" ]]; then
+        install_kicad_for_25
+        export ESIM_SKIP_KICAD=1
+    else
+        export ESIM_SKIP_KICAD=0
+    fi
+
+    # Execute final script
+    echo "Running: $SCRIPT $ARGUMENT"
+    bash "$SCRIPT" "$ARGUMENT"
+}
+
+# ============================================================
+# MAIN LOGIC
+# ============================================================
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 --install | --uninstall"
+    exit 1
+fi
+
+ARGUMENT=$1
+if [[ "$ARGUMENT" != "--install" && "$ARGUMENT" != "--uninstall" ]]; then
+    echo "Usage: $0 --install | --uninstall"
+    exit 1
+fi
+
+get_ubuntu_version
+run_version_script
+

--- a/installer/install-nghdl-25.04.sh
+++ b/installer/install-nghdl-25.04.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+nghdl="nghdl-simulator"
+ghdl="ghdl-4.1.0"
+verilator="verilator-4.210"
+config_dir="$HOME/.nghdl"
+config_file="config.ini"
+src_dir=`pwd`
+
+error_exit() {
+    echo -e "\n\nError! Kindly resolve above error(s) and try again."
+    echo -e "Aborting Installation...\n"
+    exit 1
+}
+
+###############################################
+# LLVM FIX FOR UBUNTU 25.04
+###############################################
+installLLVM() {
+
+    ubuntu_ver=$(lsb_release -rs)
+
+    echo "Installing LLVM for GHDL..."
+
+    if dpkg --compare-versions "$ubuntu_ver" ge "25.04"; then
+        echo "Ubuntu 25.04 detected — Installing LLVM 15 + clang++-15"
+
+        sudo apt install -y llvm-15 llvm-15-dev clang-15 clang-format-15 clang-tidy-15 clang-tools-15 zlib1g-dev
+
+        sudo ln -sf /usr/bin/llvm-config-15 /usr/bin/llvm-config
+        sudo ln -sf /usr/bin/clang++-15 /usr/bin/clang++
+        sudo ln -sf /usr/bin/clang-15 /usr/bin/clang
+
+    else
+        echo "Using system LLVM..."
+        sudo apt install -y llvm llvm-dev clang zlib1g-dev
+    fi
+}
+
+###############################################
+# INSTALL DEPENDENCIES
+###############################################
+installDependency() {
+
+    echo "Installing Make, GNAT..."
+    sudo apt install -y make gnat
+
+    installLLVM
+
+    echo "Installing graphics dependencies..."
+    sudo apt install -y libxaw7 libxaw7-dev
+
+    echo "Installing Verilator deps..."
+    sudo apt install -y autoconf g++ flex bison
+}
+
+###############################################
+# INSTALL GHDL (LLVM backend)
+###############################################
+installGHDL() {
+
+    echo "Installing $ghdl..."
+
+    tar xvf $ghdl.tar.gz
+    cd $ghdl/
+
+    chmod +x configure
+    ./configure --with-llvm-config=/usr/bin/llvm-config
+
+    make -j$(nproc)
+    sudo make install
+
+    cd ../
+    echo "GHDL installed successfully."
+}
+
+###############################################
+# INSTALL VERILATOR
+###############################################
+installVerilator() {
+
+    echo "Installing $verilator..."
+
+    tar -xvf $verilator.tar.xz
+    cd $verilator
+
+    chmod +x configure
+    ./configure
+    make -j$(nproc)
+    sudo make install
+
+    cd ../
+    echo "Verilator installed successfully."
+}
+
+###############################################
+# INSTALL NGHDL (Ngspice Digital)
+###############################################
+installNGHDL() {
+
+    echo "Installing NGHDL..."
+
+    cd $src_dir
+    tar -xJf $nghdl-source.tar.xz -C $HOME
+    mv $HOME/$nghdl-source $HOME/$nghdl
+
+    cd $HOME/$nghdl
+
+    mkdir -p install_dir release
+    cd release
+
+    chmod +x ../configure
+    ../configure --enable-xspice --disable-debug \
+        --prefix=$HOME/$nghdl/install_dir/ \
+        --exec-prefix=$HOME/$nghdl/install_dir/
+
+    make -j$(nproc)
+    make install
+
+    sudo chmod 755 $HOME/$nghdl/install_dir/bin/ngspice
+    sudo rm -f /usr/bin/ngspice
+    sudo ln -sf $HOME/$nghdl/install_dir/bin/ngspice /usr/bin/ngspice
+
+    echo "NGHDL installed successfully."
+}
+
+###############################################
+# CREATE CONFIG
+###############################################
+createConfigFile() {
+
+    mkdir -p $config_dir
+    rm -f $config_dir/$config_file
+
+    echo "[NGHDL]" >> $config_dir/$config_file
+    echo "NGHDL_HOME = $HOME/$nghdl" >> $config_dir/$config_file
+    echo "DIGITAL_MODEL = %(NGHDL_HOME)s/src/xspice/icm" >> $config_dir/$config_file
+    echo "RELEASE = %(NGHDL_HOME)s/release" >> $config_dir/$config_file
+    echo "[SRC]" >> $config_dir/$config_file
+    echo "SRC_HOME = $src_dir" >> $config_dir/$config_file
+    echo "LICENSE = %(SRC_HOME)s/LICENSE" >> $config_dir/$config_file
+}
+
+###############################################
+# CREATE SOFTLINK
+###############################################
+createSoftLink() {
+
+    sudo chmod 755 $src_dir/src/ngspice_ghdl.py
+    sudo ln -sf $src_dir/src/ngspice_ghdl.py /usr/local/bin/nghdl
+
+    echo "Softlink for NGHDL created."
+}
+
+###############################################
+# MAIN EXECUTION
+###############################################
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 --install"
+    exit 1
+fi
+
+option=$1
+
+if [[ "$option" == "--install" ]]; then
+
+    set -e
+    set -E
+    trap error_exit ERR
+
+    installDependency
+    installGHDL
+    installVerilator
+    installNGHDL
+    createConfigFile
+    createSoftLink
+
+    echo "---------- NGHDL Installed Successfully ----------"
+
+else
+    echo "Invalid option."
+    exit 1
+fi
+

--- a/installer/install-nghdl.sh
+++ b/installer/install-nghdl.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# ============================================================
+# Detect Ubuntu version (fixed for 25.04)
+# ============================================================
+get_ubuntu_version() {
+    VERSION_ID=$(grep "^VERSION_ID" /etc/os-release | cut -d '"' -f 2)
+    FULL_VERSION=$(lsb_release -rs)      # Reliable on all Ubuntu versions
+
+    echo "Detected Ubuntu Version: $FULL_VERSION"
+}
+
+# ============================================================
+# Select correct NGHDL installer script
+# ============================================================
+run_version_script() {
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-nghdl-scripts"
+
+    case "$VERSION_ID" in
+        "22.04")
+            SCRIPT="$SCRIPT_DIR/install-nghdl-23.04.sh"
+            ;;
+        "23.04")
+            SCRIPT="$SCRIPT_DIR/install-nghdl-23.04.sh"
+            ;;
+        "24.04")
+            SCRIPT="$SCRIPT_DIR/install-nghdl-24.04.sh"
+            ;;
+        "25.04")
+            echo "Ubuntu 25.04 detected — using 24.04 NGHDL installer (compatible)."
+            SCRIPT="$SCRIPT_DIR/install-nghdl-24.04.sh"
+            ;;
+        *)
+            echo "Unsupported Ubuntu version: $VERSION_ID ($FULL_VERSION)"
+            exit 1
+            ;;
+    esac
+
+    if [[ -f "$SCRIPT" ]]; then
+        echo "Running NGHDL script: $SCRIPT $ARGUMENT"
+        bash "$SCRIPT" "$ARGUMENT"
+    else
+        echo "ERROR: Installer script not found: $SCRIPT"
+        exit 1
+    fi
+}
+
+# ============================================================
+# MAIN EXECUTION
+# ============================================================
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 --install | --uninstall"
+    exit 1
+fi
+
+ARGUMENT=$1
+
+if [[ "$ARGUMENT" != "--install" && "$ARGUMENT" != "--uninstall" ]]; then
+    echo "Invalid argument: $ARGUMENT"
+    echo "Usage: $0 --install | --uninstall"
+    exit 1
+fi
+
+get_ubuntu_version
+run_version_script
+


### PR DESCRIPTION
### Related Issues

Fixes installer failures on Ubuntu 25.04

Addresses KiCad PPA removal (404 Not Found)

Fixes NGHDL installation crashes

Fixes GHDL build errors caused by missing clang++

Fixes incorrect Ubuntu version detection

Fixes extraction error for nghdl-simulator-source.tar.xz

Fixes missing ~/.nghdl/config.ini

Fixes LLVM incompatibility (Ubuntu ships LLVM 18, installer needs LLVM 15)

### Purpose

Ubuntu 25.04 (Plucky) is not officially supported by the existing eSim installer.
Running install-eSim.sh results in multiple critical failures:

KiCad 6.0 PPA not available

Unsupported VERSION_ID format

Missing system packages (GTK Canberra)

LLVM version mismatch causing GHDL build failure

NGHDL installation incomplete

Incorrect tar filename for NGHDL source

Broken symlinks (ngspice)

Missing configuration files causing NGHDL GUI crash

The purpose of this update is to patch the installer scripts so that eSim 2.5 installs correctly on Ubuntu 25.04.

### Approach

The patch applies multiple fixes:

Ubuntu Version Detection Fix

Uses lsb_release -rs for reliable version parsing.

KiCad PPA Removal

Skips PPA setup on 25.04.

Installs KiCad from Ubuntu repo instead.

Dependency Cleanup

Removes obsolete libcanberra-gtk-module packages.

Installs clang-15 and symlinks to clang++.

LLVM Compatibility Fix

Forces installer to use llvm-15 instead of system LLVM 18.

NGHDL Source Extraction Fix

Corrected filename to nghdl-simulator-source.tar.xz.

NGHDL Build Enhancements

Regenerated config.ini

Fixed ngspice symlink

Corrected --prefix paths

Installer Routing Update

Ubuntu 25.04 is now redirected to the 24.04 script, improving compatibility.

Error Handling Improvements

Cleaner abort messages

Better environment checks

Restores ngspice path automatically

These changes ensure the installer completes successfully on Ubuntu 25.04.