### PR TITLE
Feature: Add IHP Open PDK installation support to Ubuntu installer scripts

### DIFF
--- a/Ubuntu/install-eSim-scripts/install-eSim-22.04.sh
+++ b/Ubuntu/install-eSim-scripts/install-eSim-22.04.sh
@@ -15,6 +15,8 @@
 #       AUTHORS: Fahim Khan, Rahul Paknikar, Saurabh Bansode,
 #                Sumanto Kar, Partha Singha Roy, Shiva Krishna Sangati,
 #                Jayanth Tatineni, Anshul Verma
+#       MENTORS: Sumanto Kar, Varad Patil, Shanti Priya K, Aditya M
+#       INTERNS: Akshay Rukade, Haripriyan R
 #  ORGANIZATION: eSim Team, FOSSEE, IIT Bombay
 #       CREATED: Wednesday 15 July 2015 15:26
 #      REVISION: Sunday 25 May 2025 17:40
@@ -101,6 +103,29 @@ function installSky130Pdk
     # Change ownership from root to the user
     sudo chown -R $USER:$USER /usr/share/local/sky130_fd_pr/
 
+}
+
+function installIhpPdk
+{
+    echo -n "Do you want to install IHP Open PDK for analog IC design? (y/n): "
+    read installIhp
+    
+    if [ "$installIhp" == "y" -o "$installIhp" == "Y" ]; then
+        echo "Installing IHP Open PDK........................"
+        
+        if [ -f "ihp/ihp-install-script.sh" ]; then
+            cd ihp/
+            chmod +x ihp-install-script.sh
+            trap "" ERR
+            ./ihp-install-script.sh --install
+            trap error_exit ERR
+            cd ../
+        else
+            echo "IHP install script not found. Skipping..."
+        fi
+    else
+        echo "Skipping IHP Open PDK installation"
+    fi
 }
 
 
@@ -383,6 +408,7 @@ if [ $option == "--install" ];then
     copyKicadLibrary
     installNghdl
     installSky130Pdk
+    installIhpPdk
     createDesktopStartScript
 
     if [ $? -ne 0 ];then
@@ -412,6 +438,14 @@ elif [ $option == "--uninstall" ];then
 
         echo "Removing SKY130 PDK......................"
         sudo rm -R /usr/share/local/sky130_fd_pr
+
+        echo "Removing IHP Open PDK...................."
+        if [ -f "ihp/install-ihp-openpdk.sh" ]; then
+            cd ihp/
+            chmod +x install-ihp-openpdk.sh
+            ./install-ihp-openpdk.sh --uninstall
+            cd ../
+        fi
 
         echo "Removing NGHDL..........................."
         rm -rf library/modelParamXML/Nghdl/*

--- a/Ubuntu/install-eSim-scripts/install-eSim-23.04.sh
+++ b/Ubuntu/install-eSim-scripts/install-eSim-23.04.sh
@@ -15,6 +15,8 @@
 #       AUTHORS: Fahim Khan, Rahul Paknikar, Saurabh Bansode,
 #                Sumanto Kar, Partha Singha Roy, Jayanth Tatineni,
 #                Anshul Verma
+#       MENTORS: Sumanto Kar, Varad Patil, Shanti Priya K, Aditya M
+#       INTERNS: Akshay Rukade, Haripriyan R
 #  ORGANIZATION: eSim Team, FOSSEE, IIT Bombay
 #       CREATED: Wednesday 15 July 2015 15:26
 #      REVISION: Sunday 25 May 2025 17:40
@@ -175,11 +177,37 @@ function installSky130Pdk
     sudo mv /usr/share/local/volare/sky130/versions/0fe599b2afb6708d281543108caf8310912f54af/sky130A/libs.ref/sky130_fd_pr /usr/share/local/
     rm -rf /usr/share/local/volare/
 
+
     # Change ownership from root to the user
     sudo chown -R $USER:$USER /usr/share/local/sky130_fd_pr/
 
 
 }
+
+
+function installIhpPdk
+{
+    echo -n "Do you want to install IHP Open PDK for analog IC design? (y/n): "
+    read installIhp
+    
+    if [ "$installIhp" == "y" -o "$installIhp" == "Y" ]; then
+        echo "Installing IHP Open PDK........................"
+        
+        if [ -f "ihp/ihp-install-script.sh" ]; then
+            cd ihp/
+            chmod +x ihp-install-script.sh
+            trap "" ERR
+            ./ihp-install-script.sh --install
+            trap error_exit ERR
+            cd ../
+        else
+            echo "IHP install script not found. Skipping..."
+        fi
+    else
+        echo "Skipping IHP Open PDK installation"
+    fi
+}
+
 
 
 function installKicad
@@ -426,6 +454,7 @@ if [ $option == "--install" ];then
     copyKicadLibrary
     installNghdl
     installSky130Pdk
+    installIhpPdk
     createDesktopStartScript
 
     if [ $? -ne 0 ];then
@@ -454,6 +483,14 @@ elif [ $option == "--uninstall" ];then
 
         echo "Removing SKY130 PDK......................"
         sudo rm -rf /usr/share/local/sky130_fd_pr
+
+        echo "Removing IHP Open PDK...................."
+        if [ -f "ihp/install-ihp-openpdk.sh" ]; then
+            cd ihp/
+            chmod +x install-ihp-openpdk.sh
+            ./install-ihp-openpdk.sh --uninstall
+            cd ../
+        fi
 
         echo "Removing NGHDL..........................."
         rm -rf library/modelParamXML/Nghdl/*

--- a/Ubuntu/install-eSim-scripts/install-eSim-24.04.sh
+++ b/Ubuntu/install-eSim-scripts/install-eSim-24.04.sh
@@ -15,6 +15,8 @@
 #       AUTHORS: Fahim Khan, Rahul Paknikar, Saurabh Bansode,
 #                Sumanto Kar, Partha Singha Roy, Harsha Narayana P, 
 #                Jayanth Tatineni, Anshul Verma
+#       MENTORS: Sumanto Kar, Varad Patil, Shanti Priya K, Aditya M
+#       INTERNS: Akshay Rukade, Haripriyan R
 #  ORGANIZATION: eSim Team, FOSSEE, IIT Bombay
 #       CREATED: Wednesday 15 July 2015 15:26
 #      REVISION: Sunday 25 May 2025 17:40
@@ -101,6 +103,29 @@ function installSky130Pdk
     # Change ownership from root to the user
     sudo chown -R $USER:$USER /usr/share/local/sky130_fd_pr/
 
+}
+
+function installIhpPdk
+{
+    echo -n "Do you want to install IHP Open PDK for analog IC design? (y/n): "
+    read installIhp
+    
+    if [ "$installIhp" == "y" -o "$installIhp" == "Y" ]; then
+        echo "Installing IHP Open PDK........................"
+        
+        if [ -f "ihp/ihp-install-script.sh" ]; then
+            cd ihp/
+            chmod +x ihp-install-script.sh
+            trap "" ERR
+            ./ihp-install-script.sh --install
+            trap error_exit ERR
+            cd ../
+        else
+            echo "IHP install script not found. Skipping..."
+        fi
+    else
+        echo "Skipping IHP Open PDK installation"
+    fi
 }
 
 
@@ -399,6 +424,7 @@ if [ $option == "--install" ];then
     copyKicadLibrary
     installNghdl
     installSky130Pdk
+    installIhpPdk
     createDesktopStartScript
 
     if [ $? -ne 0 ];then
@@ -428,6 +454,14 @@ elif [ $option == "--uninstall" ];then
 
         echo "Removing SKY130 PDK......................"
         sudo rm -R /usr/share/local/sky130_fd_pr
+
+        echo "Removing IHP Open PDK...................."
+        if [ -f "ihp/install-ihp-openpdk.sh" ]; then
+            cd ihp/
+            chmod +x install-ihp-openpdk.sh
+            ./install-ihp-openpdk.sh --uninstall
+            cd ../
+        fi
 
         echo "Removing NGHDL..........................."
         rm -rf library/modelParamXML/Nghdl/*


### PR DESCRIPTION
Related Issues:
N/A

Purpose:
This PR introduces support for installing the IHP Open PDK (SG13G2) within the eSim installer scripts for Ubuntu (22.04, 23.04, and 24.04). This allows users to easily install and use the IHP PDK for analog IC design alongside the existing SKY130 PDK.

Approach:
Added a new installIhpPdk function to the Ubuntu installer scripts (install-eSim-22.04.sh, install-eSim-23.04.sh, install-eSim-24.04.sh).
Calls the IHP installation script (if present) during the main installation process.
Added corresponding logic to uninstall the IHP PDK when eSim is uninstalled.
Updated the AUTHORS section in the script headers to include the current INTERNS and MENTORS involved in this integration.