### PR TITLE
Fix workspace path newline causing new project creation failure

### DIFF
--- a/src/configuration/Appconfig.py
+++ b/src/configuration/Appconfig.py
@@ -45,6 +45,7 @@ class Appconfig(QtWidgets.QWidget):
             user_home, ".esim/workspace.txt"), 'r'
         )
         workspace_check, home = file.readline().split(' ', 1)
+        home = home.strip()
         file.close()
     except IOError:
         home = os.path.join(os.path.expanduser("~"), "eSim-Workspace")


### PR DESCRIPTION
### Related Issues
N/A

### Purpose
While running eSim from source, creating a new project fails even when a valid project name is provided.  
This occurs because the workspace path read from `~/.esim/workspace.txt` contains a trailing newline character (`\n`).  
The newline becomes part of the workspace path, resulting in invalid paths such as:

/home/user/eSim-Workspace\n/.projectExplorer.txt

which prevents project creation.

### Approach
The trailing newline is removed from the workspace path before it is used.

Updated code in `src/configuration/Appconfig.py`:

workspace_check, home = file.readline().split(' ', 1)
home = home.strip()

This ensures the workspace path is correctly formatted and allows new projects to be created successfully.