### PR TITLE
fix(gui): prevent crash on right-click in Project Explorer with no selection

### DIFF
--- a/src/frontEnd/ProjectExplorer.py
+++ b/src/frontEnd/ProjectExplorer.py
@@ -104,13 +104,17 @@ class ProjectExplorer(QtWidgets.QWidget):
         ) = []
 
     def openMenu(self, position):
-        indexes = self.treewidget.selectedIndexes()
-        if len(indexes) > 0:
-            level = 0
-            index = indexes[0]
-            while index.parent().isValid():
-                index = index.parent()
-                level += 1
+        index = self.treewidget.indexAt(position)
+        if not index.isValid():
+            return
+
+        self.treewidget.setCurrentIndex(index)
+        level = 0
+        temp_index = index
+
+        while temp_index.parent().isValid():
+            temp_index = temp_index.parent()
+            level += 1
 
         menu = QtWidgets.QMenu()
         if level == 0:
@@ -124,7 +128,7 @@ class ProjectExplorer(QtWidgets.QWidget):
             openfile = menu.addAction(self.tr("Open"))
             openfile.triggered.connect(self.openProject)
 
-        menu.exec_(self.treewidget.viewport().mapToGlobal(position))
+        menu.exec(self.treewidget.viewport().mapToGlobal(position))
 
     def openProject(self):
         self.indexItem = self.treewidget.currentIndex()


### PR DESCRIPTION
## Related Issues
Closes #509

---

## Purpose
The Project Explorer context menu crashes when a user right-clicks without selecting any item. This happens because the current implementation relies on `selectedIndexes()` and assumes that a selection is always present.

---

## Approach
- Replaced `selectedIndexes()` with `indexAt(position)` to determine the item under the cursor
- Added `index.isValid()` check to safely handle right-clicks on empty areas
- Set the clicked index as the current selection to maintain expected menu behavior
- Used a temporary index (`temp_index`) to safely traverse parent hierarchy and compute level

---

## Changes Made
- Updated `openMenu()` implementation in `ProjectExplorer.py`
- Removed unsafe access to `indexes[0]`
- Refactored logic to depend on actual user interaction instead of prior selection state
- Ensured `level` is always initialized before use

---

## Impact
- Prevents application crash on right-click with no selection
- Improves robustness and consistency of context menu behavior
- Maintains existing functionality for valid selections

---

## Verification
- Right-click on empty space → no crash, no unintended behavior
- Right-click on project/file → context menu opens correctly
- Right-click on nested items → correct level detection and menu behavior