### PR TITLE
Refactor Tool Manager Subsystem for PyQt6 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ nghdl*
 tags
 build/
 dist/
+
+# Tool Manager dynamically created folders
+src/toolManager/bin/
+src/toolManager/ghdl/

--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -20,7 +20,8 @@ SYSTEM     = platform.system()
 IS_WINDOWS = SYSTEM == "Windows"
 IS_LINUX   = SYSTEM == "Linux"
 
-BASE_DIR = r"C:\FOSSEE\Tool-Manager"
+import os
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 if IS_WINDOWS:
     BACKEND = os.path.join(BASE_DIR, "tool_manager_windows.py")
@@ -343,7 +344,7 @@ class ToolManagerGUI(QWidget):
             status.setStyleSheet("color:orange;")
             self.table.setCellWidget(row, 4, status)
 
-            chk.stateChanged.connect(lambda s, c=combo: c.setEnabled(s == Qt.CheckState.Checked))
+            chk.stateChanged.connect(lambda s, c=combo: c.setEnabled(s == Qt.CheckState.Checked.value))
             self.rows[tool] = {
                 "checkbox": chk, "combo": combo,
                 "installed": installed, "status": status

--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -5,9 +5,11 @@ import ctypes
 import subprocess
 import platform
 from PyQt6.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QHBoxLayout,
-    QTableWidget, QCheckBox, QComboBox,
-    QPushButton, QLabel, QMessageBox, QTextEdit, QInputDialog, QLineEdit
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QTableWidget, QTableWidgetItem, QHeaderView, QProgressBar,
+    QCheckBox, QComboBox,
+    QPushButton, QLabel, QMessageBox, QTextEdit, QInputDialog, QLineEdit,
+    QAbstractItemView
 )
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QFont
@@ -308,7 +310,7 @@ class ToolManagerGUI(QWidget):
             ["Tool", "Version", "Description", "Installed Version", "Status"]
         )
         self.table.verticalHeader().setVisible(False)
-        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.table.setColumnWidth(0, 150)
         self.table.setColumnWidth(1, 150)
         self.table.setColumnWidth(2, 400)

--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -153,12 +153,12 @@ class UninstallWindow(QWidget):
 
         title = QLabel("Uninstall Tools")
         title.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
-        title.setAlignment(Qt.AlignCenter)
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
         warn = QLabel("⚠  Selected tools will be permanently removed.")
         warn.setFont(font_small)
-        warn.setAlignment(Qt.AlignCenter)
+        warn.setAlignment(Qt.AlignmentFlag.AlignCenter)
         warn.setStyleSheet("color:#e67e22;")
         layout.addWidget(warn)
 
@@ -219,9 +219,9 @@ class UninstallWindow(QWidget):
         reply = QMessageBox.question(
             self, "Confirm Uninstall",
             "Permanently uninstall:\n\n  " + "\n  ".join(selected) + "\n\nThis cannot be undone.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.btn_uninstall.setEnabled(False)
@@ -300,7 +300,7 @@ class ToolManagerGUI(QWidget):
 
         title = QLabel("Tool Manager for eSim")
         title.setFont(QFont("Segoe UI", 15, QFont.Weight.Bold))
-        title.setAlignment(Qt.AlignCenter)
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
         self.table = QTableWidget(len(TOOLS), 5)
@@ -341,7 +341,7 @@ class ToolManagerGUI(QWidget):
             status.setStyleSheet("color:orange;")
             self.table.setCellWidget(row, 4, status)
 
-            chk.stateChanged.connect(lambda s, c=combo: c.setEnabled(s == Qt.Checked))
+            chk.stateChanged.connect(lambda s, c=combo: c.setEnabled(s == Qt.CheckState.Checked))
             self.rows[tool] = {
                 "checkbox": chk, "combo": combo,
                 "installed": installed, "status": status
@@ -578,13 +578,13 @@ if __name__ == "__main__":
         app = QApplication(sys.argv)
         msg = QMessageBox()
         msg.setWindowTitle("Administrator Required")
-        msg.setIcon(QMessageBox.Warning)
+        msg.setIcon(QMessageBox.Icon.Warning)
         msg.setText(
             "Tool Manager needs Administrator privileges to install/update tools.\n\n"
             "Click OK to relaunch as Administrator."
         )
-        msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        if msg.exec() == QMessageBox.Ok:
+        msg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
+        if msg.exec() == QMessageBox.StandardButton.Ok:
             relaunch_as_admin()
         sys.exit(0)
 

--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -4,13 +4,13 @@ import sys
 import ctypes
 import subprocess
 import platform
-from PyQt5.QtWidgets import (
+from PyQt6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout,
     QTableWidget, QCheckBox, QComboBox,
     QPushButton, QLabel, QMessageBox, QTextEdit, QInputDialog, QLineEdit
 )
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
-from PyQt5.QtGui import QFont
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QFont
 import logging
 
 PYTHON     = sys.executable
@@ -145,14 +145,14 @@ class UninstallWindow(QWidget):
     def _build_ui(self):
         font_normal = QFont("Segoe UI", 11)
         font_small  = QFont("Segoe UI", 9)
-        font_bold   = QFont("Segoe UI", 11, QFont.Bold)
+        font_bold   = QFont("Segoe UI", 11, QFont.Weight.Bold)
 
         layout = QVBoxLayout(self)
         layout.setSpacing(8)
         layout.setContentsMargins(16, 14, 16, 14)
 
         title = QLabel("Uninstall Tools")
-        title.setFont(QFont("Segoe UI", 14, QFont.Bold))
+        title.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
         title.setAlignment(Qt.AlignCenter)
         layout.addWidget(title)
 
@@ -293,13 +293,13 @@ class ToolManagerGUI(QWidget):
         self.check_all()
 
     def build_ui(self):
-        font_header = QFont("Segoe UI", 11, QFont.Bold)
+        font_header = QFont("Segoe UI", 11, QFont.Weight.Bold)
         font_normal = QFont("Segoe UI", 11)
 
         layout = QVBoxLayout(self)
 
         title = QLabel("Tool Manager for eSim")
-        title.setFont(QFont("Segoe UI", 15, QFont.Bold))
+        title.setFont(QFont("Segoe UI", 15, QFont.Weight.Bold))
         title.setAlignment(Qt.AlignCenter)
         layout.addWidget(title)
 
@@ -584,7 +584,7 @@ if __name__ == "__main__":
             "Click OK to relaunch as Administrator."
         )
         msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        if msg.exec_() == QMessageBox.Ok:
+        if msg.exec() == QMessageBox.Ok:
             relaunch_as_admin()
         sys.exit(0)
 
@@ -592,4 +592,4 @@ if __name__ == "__main__":
     setup_logging()
     gui = ToolManagerGUI()
     gui.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -298,7 +298,7 @@ class ToolManagerWindow(QMainWindow):
             "color: #d4d4d4; background: transparent;"
         )
         self.progress_log.setWordWrap(True)
-        self.progress_log.setAlignment(Qt.AlignTop)
+        self.progress_log.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.progress_log.setMinimumHeight(60)
         pf_layout.addWidget(self.progress_log)
 
@@ -751,7 +751,7 @@ def main():
     win = ToolManagerWindow()
     win.show()
 
-    screen = app.desktop().screenGeometry()
+    screen = app.primaryScreen().geometry()
     win.move(
         (screen.width()  - win.width())  // 2,
         (screen.height() - win.height()) // 3

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -222,7 +222,7 @@ class ToolManagerWindow(QMainWindow):
         rbtn = QPushButton("↻ Refresh")
         rbtn.setFont(QFont("Arial", 9))
         rbtn.setFixedHeight(26)
-        rbtn.setCursor(Qt.PointingHandCursor)
+        rbtn.setCursor(Qt.CursorShape.PointingHandCursor)
         rbtn.setStyleSheet("""
             QPushButton {
                 background: #e9ecef; border: 1px solid #ced4da;
@@ -358,7 +358,7 @@ class ToolManagerWindow(QMainWindow):
 
         btn = QPushButton(btn_text)
         btn.setFont(QFont("Arial", 11, QFont.Weight.Bold))
-        btn.setCursor(Qt.PointingHandCursor)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
         btn.setMinimumHeight(40)
         btn.setStyleSheet(f"""
             QPushButton {{
@@ -387,7 +387,7 @@ class ToolManagerWindow(QMainWindow):
 
         btn = QPushButton("⚙   Open Full Tool Manager")
         btn.setFont(QFont("Arial", 11, QFont.Weight.Bold))
-        btn.setCursor(Qt.PointingHandCursor)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
         btn.setFixedHeight(50)
         btn.setStyleSheet("""
             QPushButton {
@@ -459,7 +459,7 @@ class ToolManagerWindow(QMainWindow):
         def make_btn(text, color, callback):
             b = QPushButton(text)
             b.setFont(QFont("Arial", 10))
-            b.setCursor(Qt.PointingHandCursor)
+            b.setCursor(Qt.CursorShape.PointingHandCursor)
             b.setFixedHeight(46)
             dark = darken_color(color, 0.1)
             b.setStyleSheet(f"""
@@ -488,13 +488,13 @@ class ToolManagerWindow(QMainWindow):
 
         sep = QLabel("— or uninstall tools individually via Full Tool Manager —")
         sep.setFont(QFont("Arial", 9))
-        sep.setAlignment(Qt.AlignCenter)
+        sep.setAlignment(Qt.AlignmentFlag.AlignCenter)
         sep.setStyleSheet("color: #aaa;")
         layout.addWidget(sep)
 
         indiv = QPushButton("⚙   Open Full Tool Manager (Individual Uninstall)")
         indiv.setFont(QFont("Arial", 10))
-        indiv.setCursor(Qt.PointingHandCursor)
+        indiv.setCursor(Qt.CursorShape.PointingHandCursor)
         indiv.setFixedHeight(40)
         indiv.setStyleSheet("""
             QPushButton {
@@ -584,9 +584,9 @@ class ToolManagerWindow(QMainWindow):
             "  • eSim\n  • KiCad (latest)\n  • Ngspice (latest)\n\n"
             "Estimated size: ~1.5 GB\n"
             "This may take 20–40 minutes.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self._run_install(
                 [(t, TOOL_VERSIONS[t]) for t in ANALOG_TOOLS],
                 "Analog Mode"
@@ -601,9 +601,9 @@ class ToolManagerWindow(QMainWindow):
             "  • GHDL (latest)\n  • Verilator (latest)\n  • LLVM (latest)\n\n"
             "Estimated size: ~3.0 GB\n"
             "This may take 40–80 minutes.",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self._run_install(
                 [(t, TOOL_VERSIONS[t]) for t in DIGITAL_TOOLS],
                 "Digital Mode"
@@ -672,9 +672,9 @@ class ToolManagerWindow(QMainWindow):
             "Uninstall digital packages?\n\n"
             "Removes: GHDL • Verilator • LLVM\n\n"
             "This cannot be undone!",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self._run_uninstall(
                 [("ghdl","none"), ("verilator","none"), ("llvm","none")],
                 "Digital packages"
@@ -686,9 +686,9 @@ class ToolManagerWindow(QMainWindow):
             "Uninstall analog packages?\n\n"
             "Removes: KiCad • Ngspice\n\n"
             "This cannot be undone!",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self._run_uninstall(
                 [("kicad","none"), ("ngspice","none")],
                 "Analog packages"
@@ -701,9 +701,9 @@ class ToolManagerWindow(QMainWindow):
             "Removes: eSim • KiCad • Ngspice\n"
             "         GHDL • Verilator • LLVM\n\n"
             "This cannot be undone!",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             self._run_uninstall(
                 [(t, "none") for t in DIGITAL_TOOLS],
                 "All packages"
@@ -733,14 +733,14 @@ def main():
         app = QApplication(sys.argv)
         msg = QMessageBox()
         msg.setWindowTitle("Administrator Required")
-        msg.setIcon(QMessageBox.Warning)
+        msg.setIcon(QMessageBox.Icon.Warning)
         msg.setText(
             "eSim Tool Manager needs Administrator privileges\n"
             "to install and update tools.\n\n"
             "Click OK to relaunch as Administrator."
         )
-        msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        if msg.exec() == QMessageBox.Ok:
+        msg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
+        if msg.exec() == QMessageBox.StandardButton.Ok:
             relaunch_as_admin()
         sys.exit(0)
 

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -5,13 +5,13 @@ import json
 import ctypes
 import subprocess
 from pathlib import Path
-from PyQt5.QtWidgets import (
+from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout,
     QHBoxLayout, QPushButton, QLabel, QTabWidget,
     QMessageBox, QFrame, QProgressBar
 )
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
-from PyQt5.QtGui import QFont
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QFont
 
 # ==================== CONFIG ====================
 BASE_DIR = Path(__file__).resolve().parent
@@ -176,7 +176,7 @@ class ToolManagerWindow(QMainWindow):
         vbox = QVBoxLayout()
         vbox.setSpacing(5)
         t1 = QLabel("eSim Tool Manager")
-        t1.setFont(QFont("Arial", 24, QFont.Bold))
+        t1.setFont(QFont("Arial", 24, QFont.Weight.Bold))
         t1.setStyleSheet("color: white; background: transparent;")
         t2 = QLabel("Package Management System  •  Windows Edition")
         t2.setFont(QFont("Arial", 11))
@@ -200,7 +200,7 @@ class ToolManagerWindow(QMainWindow):
         layout.setContentsMargins(30, 12, 30, 12)
 
         lbl = QLabel("📦 Installed:")
-        lbl.setFont(QFont("Arial", 10, QFont.Bold))
+        lbl.setFont(QFont("Arial", 10, QFont.Weight.Bold))
         lbl.setStyleSheet("color: #666; background: transparent;")
         layout.addWidget(lbl)
 
@@ -288,7 +288,7 @@ class ToolManagerWindow(QMainWindow):
         pf_layout.setSpacing(6)
 
         pf_title = QLabel("Installation Progress")
-        pf_title.setFont(QFont("Arial", 9, QFont.Bold))
+        pf_title.setFont(QFont("Arial", 9, QFont.Weight.Bold))
         pf_title.setStyleSheet("color: #aaa; background: transparent;")
         pf_layout.addWidget(pf_title)
 
@@ -333,7 +333,7 @@ class ToolManagerWindow(QMainWindow):
         layout.setSpacing(10)
 
         t = QLabel(title)
-        t.setFont(QFont("Arial", 13, QFont.Bold))
+        t.setFont(QFont("Arial", 13, QFont.Weight.Bold))
         t.setStyleSheet("color: #333; background: transparent;")
         layout.addWidget(t)
 
@@ -357,7 +357,7 @@ class ToolManagerWindow(QMainWindow):
         bottom.addStretch()
 
         btn = QPushButton(btn_text)
-        btn.setFont(QFont("Arial", 11, QFont.Bold))
+        btn.setFont(QFont("Arial", 11, QFont.Weight.Bold))
         btn.setCursor(Qt.PointingHandCursor)
         btn.setMinimumHeight(40)
         btn.setStyleSheet(f"""
@@ -386,7 +386,7 @@ class ToolManagerWindow(QMainWindow):
         layout.addWidget(desc)
 
         btn = QPushButton("⚙   Open Full Tool Manager")
-        btn.setFont(QFont("Arial", 11, QFont.Bold))
+        btn.setFont(QFont("Arial", 11, QFont.Weight.Bold))
         btn.setCursor(Qt.PointingHandCursor)
         btn.setFixedHeight(50)
         btn.setStyleSheet("""
@@ -438,7 +438,7 @@ class ToolManagerWindow(QMainWindow):
         wl = QVBoxLayout(warn)
         wl.setContentsMargins(16, 12, 16, 12)
         wt = QLabel("⚠️  Warning")
-        wt.setFont(QFont("Arial", 12, QFont.Bold))
+        wt.setFont(QFont("Arial", 12, QFont.Weight.Bold))
         wt.setStyleSheet("color: #856404; background: transparent;")
         wd = QLabel(
             "Uninstalling packages will remove them permanently. "
@@ -518,7 +518,7 @@ class ToolManagerWindow(QMainWindow):
         layout.setSpacing(15)
         
         title = QLabel("About eSim Tool Manager")
-        title.setFont(QFont("Segoe UI", 18, QFont.Bold))
+        title.setFont(QFont("Segoe UI", 18, QFont.Weight.Bold))
         title.setStyleSheet("color: #0056b3; margin-bottom: 5px;")
         layout.addWidget(title)        
 
@@ -740,7 +740,7 @@ def main():
             "Click OK to relaunch as Administrator."
         )
         msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        if msg.exec_() == QMessageBox.Ok:
+        if msg.exec() == QMessageBox.Ok:
             relaunch_as_admin()
         sys.exit(0)
 
@@ -756,7 +756,7 @@ def main():
         (screen.width()  - win.width())  // 2,
         (screen.height() - win.height()) // 3
     )
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -214,7 +214,7 @@ class ToolManagerWindow(QMainWindow):
                         f"<span style='color:#999;'>—</span>")
             l2 = QLabel(text)
             l2.setFont(QFont("Arial", 9))
-            l2.setStyleSheet("background: transparent; margin-left: 10px;")
+            l2.setStyleSheet("color: #555; background: transparent; margin-left: 10px;")
             layout.addWidget(l2)
 
         layout.addStretch()

--- a/src/toolManager/tool_manager_windows.py
+++ b/src/toolManager/tool_manager_windows.py
@@ -18,7 +18,7 @@ if sys.platform == "win32":
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='ignore')
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='ignore')
 
-BASE_DIR = Path(r"C:\FOSSEE\Tool-Manager")
+BASE_DIR = Path(__file__).resolve().parent
 STATE_FILE = BASE_DIR / "information.json"
 BASE_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/src/toolManager/tool_manager_windows.py
+++ b/src/toolManager/tool_manager_windows.py
@@ -342,11 +342,11 @@ def find_llvm_fixed(version=None):
 
 def find_pyqt_fixed(version=None):
     try:
-        result = run_cmd_safe([sys.executable, "-c", "import PyQt5.QtCore; print(PyQt5.QtCore.PYQT_VERSION_STR)"])
+        result = run_cmd_safe([sys.executable, "-c", "import PyQt6.QtCore; print(PyQt6.QtCore.PYQT_VERSION_STR)"])
         if result and result.returncode == 0:
             found_ver = result.stdout.strip()
             if version is None or found_ver.startswith(str(version)):
-                return "PyQt5", found_ver
+                return "PyQt6", found_ver
     except:
         pass
     
@@ -360,13 +360,13 @@ def find_pyqt_fixed(version=None):
         pass
     
     try:
-        result = run_cmd_safe([sys.executable, "-m", "pip", "show", "PyQt5"])
+        result = run_cmd_safe([sys.executable, "-m", "pip", "show", "PyQt6"])
         if result and result.returncode == 0:
             for line in result.stdout.split('\n'):
                 if line.lower().startswith('version:'):
                     found_ver = line.split(':')[1].strip()
                     if version is None or found_ver.startswith(str(version)):
-                        return "PyQt5", found_ver
+                        return "PyQt6", found_ver
     except:
         pass
     
@@ -916,7 +916,7 @@ def install_pyqt(target_version, upgrade=False):
     if target_version.startswith("6.") or target_version == "latest":
         package = "PyQt6"
     else:
-        package = "PyQt5"
+        package = "PyQt6"
     
     if target_version == "latest":
         cmd = [sys.executable, "-m", "pip", "install", package, "--upgrade"]

--- a/src/toolManager/updater_gui.py
+++ b/src/toolManager/updater_gui.py
@@ -179,9 +179,9 @@ class PackageUpdaterWindow(QMainWindow):
             current_item = QTableWidgetItem(current_ver)
             current_item.setFont(QFont("Segoe UI", 9))
             if current_ver != 'Not installed':
-                current_item.setForeground(Qt.darkGreen)
+                current_item.setForeground(Qt.GlobalColor.darkGreen)
             else:
-                current_item.setForeground(Qt.red)
+                current_item.setForeground(Qt.GlobalColor.red)
             self.table.setItem(row, 2, current_item)
             
             if current_ver in self.available_versions[package_name]:
@@ -290,9 +290,9 @@ class PackageUpdaterWindow(QMainWindow):
             current_item = QTableWidgetItem(current_ver)
             current_item.setFont(QFont("Segoe UI", 9))
             if current_ver != 'Not installed':
-                current_item.setForeground(Qt.darkGreen)
+                current_item.setForeground(Qt.GlobalColor.darkGreen)
             else:
-                current_item.setForeground(Qt.red)
+                current_item.setForeground(Qt.GlobalColor.red)
             self.table.setItem(row, 2, current_item)
             
             combo = QComboBox()

--- a/src/toolManager/updater_gui.py
+++ b/src/toolManager/updater_gui.py
@@ -4,13 +4,13 @@ import subprocess
 import json
 import os
 import re
-from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
+from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
                              QHBoxLayout, QPushButton, QLabel, QCheckBox,
                              QComboBox, QMessageBox, QFrame, QProgressBar,
                              QTableWidget, QTableWidgetItem, QHeaderView,
                              QAbstractItemView)
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
-from PyQt5.QtGui import QFont
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QFont
 
 class InstallerThread(QThread):
     progress = pyqtSignal(str, int)
@@ -365,7 +365,7 @@ class PackageUpdaterWindow(QMainWindow):
         
         title_layout = QVBoxLayout()
         title = QLabel("Package Updater")
-        title.setFont(QFont("Segoe UI", 14, QFont.Bold))
+        title.setFont(QFont("Segoe UI", 14, QFont.Weight.Bold))
         title.setStyleSheet("color: white; background: transparent;")
         
         subtitle = QLabel("Real-time progress • Ngspice 35-43 • Ubuntu 22.04")
@@ -442,7 +442,7 @@ class PackageUpdaterWindow(QMainWindow):
         
         self.update_btn = QPushButton("Update Selected")
         self.update_btn.setFixedSize(120, 28)
-        self.update_btn.setFont(QFont("Segoe UI", 9, QFont.Bold))
+        self.update_btn.setFont(QFont("Segoe UI", 9, QFont.Weight.Bold))
         self.update_btn.setCursor(Qt.PointingHandCursor)
         self.update_btn.setStyleSheet("""
             QPushButton {
@@ -538,7 +538,7 @@ def main():
     app.setFont(QFont("Segoe UI", 9))
     window = PackageUpdaterWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/src/toolManager/updater_gui.py
+++ b/src/toolManager/updater_gui.py
@@ -277,7 +277,7 @@ class PackageUpdaterWindow(QMainWindow):
             checkbox_widget = QWidget()
             checkbox_layout = QHBoxLayout(checkbox_widget)
             checkbox_layout.addWidget(checkbox)
-            checkbox_layout.setAlignment(Qt.AlignCenter)
+            checkbox_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
             checkbox_layout.setContentsMargins(0, 0, 0, 0)
             self.table.setCellWidget(row, 0, checkbox_widget)
             self.checkboxes[package_name] = checkbox
@@ -417,7 +417,7 @@ class PackageUpdaterWindow(QMainWindow):
         
         refresh_btn = QPushButton("🔄 Refresh")
         refresh_btn.setFixedSize(85, 26)
-        refresh_btn.setCursor(Qt.PointingHandCursor)
+        refresh_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         refresh_btn.setStyleSheet(self.get_win_button_style())
         refresh_btn.clicked.connect(self.refresh_versions)
         layout.addWidget(refresh_btn)
@@ -426,14 +426,14 @@ class PackageUpdaterWindow(QMainWindow):
         
         select_btn = QPushButton("Select All")
         select_btn.setFixedSize(75, 26)
-        select_btn.setCursor(Qt.PointingHandCursor)
+        select_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         select_btn.setStyleSheet(self.get_win_button_style())
         select_btn.clicked.connect(lambda: [cb.setChecked(True) for cb in self.checkboxes.values()])
         layout.addWidget(select_btn)
         
         deselect_btn = QPushButton("Deselect All")
         deselect_btn.setFixedSize(85, 26)
-        deselect_btn.setCursor(Qt.PointingHandCursor)
+        deselect_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         deselect_btn.setStyleSheet(self.get_win_button_style())
         deselect_btn.clicked.connect(lambda: [cb.setChecked(False) for cb in self.checkboxes.values()])
         layout.addWidget(deselect_btn)
@@ -443,7 +443,7 @@ class PackageUpdaterWindow(QMainWindow):
         self.update_btn = QPushButton("Update Selected")
         self.update_btn.setFixedSize(120, 28)
         self.update_btn.setFont(QFont("Segoe UI", 9, QFont.Weight.Bold))
-        self.update_btn.setCursor(Qt.PointingHandCursor)
+        self.update_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self.update_btn.setStyleSheet("""
             QPushButton {
                 background-color: #0078d7;
@@ -502,9 +502,9 @@ class PackageUpdaterWindow(QMainWindow):
         reply = QMessageBox.question(self, 'Confirm',
                                     f'Update these packages?\n\n{pkg_list}\n\n'
                                     f'This will take several minutes.',
-                                    QMessageBox.Yes | QMessageBox.No)
+                                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         
-        if reply == QMessageBox.No:
+        if reply == QMessageBox.StandardButton.No:
             return
         
         self.progress_frame.show()

--- a/src/toolManager/updater_gui.py
+++ b/src/toolManager/updater_gui.py
@@ -260,8 +260,8 @@ class PackageUpdaterWindow(QMainWindow):
         
         self.table.horizontalHeader().setStretchLastSection(True)
         self.table.verticalHeader().setVisible(False)
-        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.table.setAlternatingRowColors(True)
         self.table.setShowGrid(True)
         


### PR DESCRIPTION
### Related Issues

- Follow-up to Tool Manager Cleanup PR #518 
- Resolves PyQt6 integration compatibility for the eSim platform

### Purpose

The core eSim architecture has officially upgraded from PyQt5 to PyQt6. Because the Tool Manager subsystem was originally built heavily reliant on PyQt5, it would immediately crash or throw severe runtime logic errors when integrated into the modern eSim environment. 

The purpose of this Pull Request is to successfully execute a foundational PyQt6 Migration, upgrading the Tool Manager codebase to adhere to the new PyQt6 APIs. This ensures that the Tool Manager can now be safely run on modern eSim builds across both Windows and Linux without deprecated API warnings or fatal startup crashes.

### Approach

To accomplish this migration safely across the entire Tool Manager subsystem, a combination of automated static analysis and manual verification was used to systematically update the framework. The exact architectural changes are detailed below:

#### 1. Global Import Refactoring
- Updated all import statements across the Tool Manager source files (e.g., from `PyQt5 import QtWidgets` → `from PyQt6 import QtWidgets`).

#### 2. Strict Enum Scoping
PyQt6 enforces strict typing for all Qt enums, removing the loose nested properties allowed in PyQt5. The following domains were strictly typed to resolve fatal startup crashes:
- **Edit Triggers:** Replaced `QAbstractItemView.NoEditTriggers` with the strictly scoped `QAbstractItemView.EditTrigger.NoEditTriggers` in `gui_fixed.py`.
- **Selection Behavior:** Updated `QAbstractItemView.SelectRows` and `SingleSelection` to their fully scoped variants (`SelectionBehavior.SelectRows` and `SelectionMode.SingleSelection`) inside `updater_gui.py`.
- **Global Colors:** Converted loose color attributes (e.g., `Qt.darkGreen`, `Qt.red`) to explicitly scoped `Qt.GlobalColor` enums.
- **Alignment Flags:** Scoped geometry alignments in checkboxes using `Qt.AlignmentFlag.AlignCenter`.

#### 3. Strict Signal State Logic
- Fixed a silent logic failure in `gui_fixed.py` where table checkboxes (`stateChanged`) failed to unlock version dropdowns. In PyQt6, checkbox states evaluate differently than PyQt5 boolean integers. The logic was updated to explicitly evaluate `state == Qt.CheckState.Checked.value` to restore interactivity.

#### 4. Deprecation Removals & API Updates
- **Screen Geometry:** Replaced the deprecated `QtWidgets.QDesktopWidget().screenGeometry()` with the modern `QtGui.QGuiApplication.primaryScreen().geometry()` to correctly center the application window on startup.
- **Execution Methods:** Eliminated legacy `.exec_()` method calls (used to execute the Tool Manager sub-process) in favor of the modern `.exec()`.

#### 5. Dynamic Path Resolution & UI Polishing
- **Directory Resolution:** Overhauled the legacy `BASE_DIR` logic in `tool_manager_windows.py` and `updater_gui.py`. Hardcoded absolute paths (e.g., `C:\FOSSEE\`) were replaced with dynamic relative resolution using `Path(__file__).resolve().parent`, completely future-proofing the installation directory structure.
- **Dark Mode Contrast:** Fixed a Windows-specific UI contrast bug where system Dark Mode would cause status bar text to become invisible by assigning explicit CSS colors.
- **Git Hygiene:** Added `.gitignore` exclusions for dynamically generated backend tool download directories (`/bin/`, `/ghdl/`).

### Verification

I have locally tested the Tool Manager on both Windows and Linux (via an Ubuntu VirtualBox). The main Tool Manager UI, the background updater sub-process, and the tool-installation routing successfully launch under the new PyQt6 framework. As a whole, the migration is functioning perfectly on a high level and establishes a stable cross-platform baseline.