### PR TITLE
fix: add missing Ngspice v40 to GUI version dropdown in gui_fixed.py

### DIFF
--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -37,7 +37,7 @@ TOOLS = {
         "desc": "PCB design and schematic capture tool"
     },
     "ngspice": {
-        "versions": ["latest", "35", "36", "37", "38", "39", "41", "42"],
+        "versions": ["latest", "35", "36", "37", "38", "39", "40", "41", "42"],
         "desc": "SPICE-based analog circuit simulator"
     },
     "llvm": {


### PR DESCRIPTION
**Related Issues**

Found while testing `feature/tool-manager-integration` on Windows.

---

**Purpose**

Ngspice version 40 is missing from the version dropdown in `gui_fixed.py`. The list jumps from `39` directly to `41`, so users cannot select or install Ngspice 40 from the GUI even though the backend `tool_manager_windows.py` fully supports it.

---

**Approach**

Added `"40"` to the versions list in `gui_fixed.py` to match the backend `NGSPICE_VERSIONS` dict which already has version 40 defined:

```python
# Before
"versions": ["latest", "35", "36", "37", "38", "39", "41", "42"]

# After
"versions": ["latest", "35", "36", "37", "38", "39", "40", "41", "42"]
```