### PR TITLE
Add unit tests for misc.py converter utilities

### DIFF
--- a/unit_tests/test_misc.py
+++ b/unit_tests/test_misc.py
@@ -1,0 +1,19 @@
+import sys
+
+sys.path.append(
+    "src/converter/schematic_converters/lib/PythonLib"
+)
+
+import misc
+
+
+def test_strip_num_from_ref_resistor():
+    assert misc.stripNumFromRef("R10") == "R"
+
+
+def test_strip_num_from_ref_capacitor():
+    assert misc.stripNumFromRef("C25") == "C"
+
+
+def test_strip_num_from_ref_transistor():
+    assert misc.stripNumFromRef("Q100") == "Q"

--- a/unit_tests/test_misc.py
+++ b/unit_tests/test_misc.py
@@ -92,3 +92,45 @@ def test_fix_inst_vsin_source():
     misc.fixInst(inst)
 
     assert inst.attrs[1].value == "SINE"
+
+def test_fix_inst_vplot2():
+    inst = MockInst(
+        "VPLOT2",
+        [MockAttr("X1"), MockAttr("VPLOT2")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[0].value == "U?"
+    assert inst.attrs[1].value == "VPLOT8"
+
+def test_fix_inst_vprint2():
+    inst = MockInst(
+        "VPRINT2",
+        [MockAttr("X1"), MockAttr("VPRINT2")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[0].value == "U?"
+    assert inst.attrs[1].value == "VPRINT"
+
+def test_fix_inst_agnd():
+    inst = MockInst(
+        "AGND",
+        [MockAttr("GND")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.type_ == "GND"
+
+def test_fix_inst_egnd():
+    inst = MockInst(
+        "EGND",
+        [MockAttr("GND")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.type_ == "GND"

--- a/unit_tests/test_misc.py
+++ b/unit_tests/test_misc.py
@@ -17,3 +17,29 @@ def test_strip_num_from_ref_capacitor():
 
 def test_strip_num_from_ref_transistor():
     assert misc.stripNumFromRef("Q100") == "Q"
+
+from io import StringIO
+
+def test_skip_to_found():
+    stream = StringIO(
+        "abc\n"
+        "def\n"
+        "*symbol transistor\n"
+        "xyz\n"
+    )
+
+    result = misc.skipTo(stream, "*symbol")
+
+    assert result == "*symbol transistor"
+
+
+def test_skip_to_not_found():
+    stream = StringIO(
+        "abc\n"
+        "def\n"
+        "xyz\n"
+    )
+
+    result = misc.skipTo(stream, "*symbol")
+
+    assert result == "__ERROR__"

--- a/unit_tests/test_misc.py
+++ b/unit_tests/test_misc.py
@@ -1,4 +1,13 @@
 import sys
+class MockAttr:
+    def __init__(self, value):
+        self.value = value
+
+
+class MockInst:
+    def __init__(self, type_, attrs):
+        self.type_ = type_
+        self.attrs = attrs
 
 sys.path.append(
     "src/converter/schematic_converters/lib/PythonLib"
@@ -43,3 +52,23 @@ def test_skip_to_not_found():
     result = misc.skipTo(stream, "*symbol")
 
     assert result == "__ERROR__"
+
+def test_fix_inst_j_reference():
+    inst = MockInst(
+        "ANY",
+        [MockAttr("J10")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[0].value == "J?"
+
+def test_fix_inst_m_reference():
+    inst = MockInst(
+        "ANY",
+        [MockAttr("M25")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[0].value == "M?"

--- a/unit_tests/test_misc.py
+++ b/unit_tests/test_misc.py
@@ -72,3 +72,23 @@ def test_fix_inst_m_reference():
     misc.fixInst(inst)
 
     assert inst.attrs[0].value == "M?"
+
+def test_fix_inst_vac_source():
+    inst = MockInst(
+        "VAC",
+        [MockAttr("V1"), MockAttr("VAC")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[1].value == "AC"
+
+def test_fix_inst_vsin_source():
+    inst = MockInst(
+        "VSIN",
+        [MockAttr("V1"), MockAttr("VSIN")]
+    )
+
+    misc.fixInst(inst)
+
+    assert inst.attrs[1].value == "SINE"


### PR DESCRIPTION
### Related Issues

Improves test coverage for the schematic converter utility module (misc.py).

### Purpose

Add automated unit tests for functions in misc.py to verify converter utility behavior and provide a foundation for future testing.

Covered functions:

stripNumFromRef()
skipTo()
fixInst()

### Approach

Created pytest-based unit tests under:

unit_tests/test_misc.py

Added test cases for:

stripNumFromRef()

Verified reference extraction:

R10 -> R
C25 -> C
Q100 -> Q
skipTo()

Verified:

target string found
target string not found (__ERROR__)

fixInst()

Verified:

J and M reference handling
voltage source transformations
plot source transformations
ground symbol normalization
