### PR TITLE
Add Microwatt NGHDL co-simulation example

### DIFF
--- a/nghdl/Example/Microwatt/README.md
+++ b/nghdl/Example/Microwatt/README.md
@@ -1,0 +1,61 @@
+# Microwatt eSim Integration
+
+## Overview
+
+This directory contains initial integration support for running the OpenPOWER Microwatt core inside the eSim/NGHDL co-simulation environment.
+
+The integration flow enables Microwatt to be compiled with GHDL and wrapped for NGHDL/XSPICE-based simulation inside eSim.
+
+## Files
+
+### `microwatt_cosim.vhdl`
+
+NGHDL-compatible wrapper for Microwatt.
+
+Exposed ports:
+
+* `clk` : Clock input
+* `rst` : Reset input
+* `uart_tx` : UART transmit output
+
+### `compile_for_nghdl.sh`
+
+Build script used to:
+
+* Compile Microwatt using GHDL
+* Build required helper objects
+* Elaborate the wrapper for NGHDL/XSPICE integration
+
+## Build Flow
+
+Run:
+
+```bash
+bash esim/compile_for_nghdl.sh
+```
+
+Successful compilation generates the NGHDL-compatible elaborated design.
+
+## eSim Workflow
+
+1. Compile Microwatt using the provided script
+2. Generate the NGHDL/XSPICE codemodel
+3. Import the generated block into eSim
+4. Create a schematic using:
+
+   * clock pulse
+   * reset pulse
+   * UART probe
+5. Run transient simulation
+
+## Current Status
+
+* Wrapper compilation successful
+* NGHDL integration validated
+* Basic schematic-level simulation setup completed
+
+## Future Work
+
+* Add memory and peripheral models
+* Expand validation workflows
+* Add example system-level designs

--- a/nghdl/Example/Microwatt/compile_for_nghdl.sh
+++ b/nghdl/Example/Microwatt/compile_for_nghdl.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# ==========================================================
+# Compile Microwatt + NGHDL wrapper
+# Full simulation-safe flow with all C helper linking
+# ==========================================================
+
+set -e
+
+ESIM_DIR="esim"
+WORK_DIR="esim/ghdl_work"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+
+echo "=============================================="
+echo " Step 0: Build required C helper objects"
+echo "=============================================="
+
+cc -O3 -Wall -c -o sim_vhpi_c.o sim_vhpi_c.c
+cc -O3 -Wall -c -o sim_console_c.o sim_console_c.c
+cc -O3 -Wall -c -o sim_bram_helpers_c.o sim_bram_helpers_c.c
+
+echo "=============================================="
+echo " Step 1: Compile Microwatt + wrapper"
+echo "=============================================="
+
+ghdl -c --std=08 --workdir="$WORK_DIR" \
+    -Wl,sim_vhpi_c.o \
+    -Wl,sim_console_c.o \
+    -Wl,sim_bram_helpers_c.o \
+    decode_types.vhdl \
+    common.vhdl \
+    wishbone_types.vhdl \
+    fetch1.vhdl \
+    utils.vhdl \
+    plrufn.vhdl \
+    cache_ram.vhdl \
+    icache.vhdl \
+    predecode.vhdl \
+    decode1.vhdl \
+    helpers.vhdl \
+    insn_helpers.vhdl \
+    control.vhdl \
+    decode2.vhdl \
+    register_file.vhdl \
+    cr_file.vhdl \
+    crhelpers.vhdl \
+    ppc_fx_insns.vhdl \
+    rotator.vhdl \
+    logical.vhdl \
+    countbits.vhdl \
+    multiply.vhdl \
+    multiply-32s.vhdl \
+    divider.vhdl \
+    execute1.vhdl \
+    loadstore1.vhdl \
+    mmu.vhdl \
+    dcache.vhdl \
+    writeback.vhdl \
+    core_debug.vhdl \
+    core.vhdl \
+    fpu.vhdl \
+    pmu.vhdl \
+    bitsort.vhdl \
+    wishbone_arbiter.vhdl \
+    wishbone_bram_wrapper.vhdl \
+    sync_fifo.vhdl \
+    wishbone_debug_master.vhdl \
+    xics.vhdl \
+    git.vhdl \
+    syscon.vhdl \
+    gpio.vhdl \
+    dmi_dtm_dummy.vhdl \
+    soc.vhdl \
+    spi_rxtx.vhdl \
+    spi_flash_ctrl.vhdl \
+    sim_console.vhdl \
+    sim_pp_uart.vhdl \
+    sim_bram_helpers.vhdl \
+    sim_bram.vhdl \
+    sim_16550_uart.vhdl \
+    foreign_random.vhdl \
+    glibc_random.vhdl \
+    glibc_random_helpers.vhdl \
+    "$ESIM_DIR/microwatt_cosim.vhdl" \
+    -e microwatt_cosim
+
+echo "=============================================="
+echo " SUCCESS"
+echo "=============================================="
+echo "Microwatt NGHDL wrapper compiled successfully"
+echo "GHDL work directory: $WORK_DIR"

--- a/nghdl/Example/Microwatt/microwatt_cosim.vhdl
+++ b/nghdl/Example/Microwatt/microwatt_cosim.vhdl
@@ -1,0 +1,131 @@
+-- =========================================================
+-- Microwatt eSim / NGHDL ultra-minimal wrapper
+-- Parser-safe scalar version
+-- =========================================================
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.common.all;
+use work.wishbone_types.all;
+
+entity microwatt_cosim is
+    port (
+        clk      : in  std_logic;
+        rst      : in  std_logic;
+        uart_tx  : out std_logic
+    );
+end entity microwatt_cosim;
+
+architecture rtl of microwatt_cosim is
+
+    --------------------------------------------------------------------
+    -- Internal SoC signals
+    --------------------------------------------------------------------
+    signal run_s       : std_ulogic;
+    signal uart_tx_s   : std_ulogic;
+
+    signal gpio_out_s  : std_ulogic_vector(31 downto 0);
+    signal gpio_dir_s  : std_ulogic_vector(31 downto 0);
+    signal gpio_in_s   : std_ulogic_vector(31 downto 0) := (others => '0');
+
+    --------------------------------------------------------------------
+    -- Dummy DRAM Wishbone signals
+    --------------------------------------------------------------------
+    signal wb_dram_in_s   : wishbone_master_out;
+    signal wb_dram_out_s  : wishbone_slave_out := wishbone_slave_out_init;
+
+    --------------------------------------------------------------------
+    -- Dummy external IO signals
+    --------------------------------------------------------------------
+    signal wb_ext_io_in_s        : wb_io_master_out;
+    signal wb_ext_io_out_s       : wb_io_slave_out := wb_io_slave_out_init;
+    signal wb_ext_is_dram_csr_s  : std_ulogic;
+    signal wb_ext_is_dram_init_s : std_ulogic;
+    signal wb_ext_is_eth_s       : std_ulogic;
+    signal wb_ext_is_sdcard_s    : std_ulogic;
+    signal wb_ext_is_lcd_s       : std_ulogic;
+
+    --------------------------------------------------------------------
+    -- Dummy DMA signals
+    --------------------------------------------------------------------
+    signal wishbone_dma_in_s   : wb_io_slave_out;
+    signal wishbone_dma_out_s  : wb_io_master_out := wb_io_master_out_init;
+
+begin
+
+    --------------------------------------------------------------------
+    -- Microwatt SoC instance
+    --------------------------------------------------------------------
+    soc_inst: entity work.soc
+        generic map (
+            MEMORY_SIZE => 524288,
+            RAM_INIT_FILE => "",
+            CLK_FREQ => 100000000,
+            SIM => true,
+            NCPUS => 1,
+            HAS_FPU => true,
+            HAS_BTC => true,
+            DISABLE_FLATTEN_CORE => false,
+            HAS_DRAM => false,
+            HAS_SPI_FLASH => false,
+            HAS_LITEETH => false,
+            HAS_UART1 => false,
+            HAS_SD_CARD => false,
+            HAS_SD_CARD2 => false,
+            HAS_LCD => false,
+            HAS_GPIO => false,
+            NGPIO => 32
+        )
+        port map (
+            rst => rst,
+            system_clk => clk,
+
+            run_out => run_s,
+            run_outs => open,
+
+            wb_dram_in => wb_dram_in_s,
+            wb_dram_out => wb_dram_out_s,
+
+            wb_ext_io_in => wb_ext_io_in_s,
+            wb_ext_io_out => wb_ext_io_out_s,
+            wb_ext_is_dram_csr => wb_ext_is_dram_csr_s,
+            wb_ext_is_dram_init => wb_ext_is_dram_init_s,
+            wb_ext_is_eth => wb_ext_is_eth_s,
+            wb_ext_is_sdcard => wb_ext_is_sdcard_s,
+            wb_ext_is_lcd => wb_ext_is_lcd_s,
+
+            wishbone_dma_in => wishbone_dma_in_s,
+            wishbone_dma_out => wishbone_dma_out_s,
+
+            ext_irq_eth => '0',
+            ext_irq_sdcard => '0',
+            ext_irq_sdcard2 => '0',
+
+            uart0_txd => uart_tx_s,
+            uart0_rxd => '1',
+
+            uart1_txd => open,
+            uart1_rxd => '0',
+
+            spi_flash_sck => open,
+            spi_flash_cs_n => open,
+            spi_flash_sdat_o => open,
+            spi_flash_sdat_oe => open,
+            spi_flash_sdat_i => (others => '1'),
+
+            gpio_out => gpio_out_s,
+            gpio_dir => gpio_dir_s,
+            gpio_in => gpio_in_s,
+
+            sw_soc_reset => open
+        );
+
+    --------------------------------------------------------------------
+    -- Scalar output
+    --------------------------------------------------------------------
+    uart_tx <= std_logic(uart_tx_s);
+
+end architecture rtl;

--- a/nghdl/README.md
+++ b/nghdl/README.md
@@ -55,6 +55,19 @@ Refer https://esim.fossee.in/ for more information.
 4. Open the desired example under `eSim/Examples/Mixed_Signal/` using the "Open Project" button, double click on the project when the project is loaded in the "Projects" window.
 5. Click on the "Simulation" button on eSim Main window.
 
+## Microwatt Example
+
+A Microwatt OpenPOWER NGHDL co-simulation example is available under:
+
+`nghdl/Example/Microwatt`
+
+This example demonstrates the integration of the OpenPOWER Microwatt core with the NGHDL/XSPICE co-simulation flow in eSim. The example includes:
+
+* `microwatt_cosim.vhdl` - NGHDL-compatible Microwatt wrapper
+* `compile_for_nghdl.sh` - GHDL compilation script for NGHDL
+* `README.md` - Usage and integration instructions
 
 ## Contribution
 Please refer [here](https://github.com/FOSSEE/nghdl/blob/master/CONTRIBUTION.md) for further details.
+
+


### PR DESCRIPTION
## Summary

This pull request adds a Microwatt NGHDL co-simulation example to eSim, complementing the Microwatt-side integration that was previously merged upstream.

## Changes

* Added `nghdl/Example/Microwatt/`
* Added `microwatt_cosim.vhdl`
* Added `compile_for_nghdl.sh`
* Added integration documentation (`README.md`)
* Added Microwatt example reference to NGHDL documentation

## Purpose

This example demonstrates how the OpenPOWER Microwatt core can be integrated with the NGHDL/XSPICE co-simulation workflow available in eSim.

## Status

* Microwatt wrapper compiles successfully with GHDL
* NGHDL codemodel generation flow validated
* Example files added for reference and future extension

## Related Work

This complements the Microwatt integration merged upstream:

https://github.com/antonblanchard/microwatt/pull/468
