### PR TITLE
Subckt files for 7 ICs by Digambar Wagholikar

### DIFF
--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_1_SN74HC158/IC_1_SN74HC158.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_1_SN74HC158/IC_1_SN74HC158.proj
@@ -1,0 +1,1 @@
+schematicFile IC_1_SN74HC158.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.kicad_prl
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.kicad_prl
@@ -1,0 +1,75 @@
+{
+  "board": {
+    "active_layer": 0,
+    "active_layer_preset": "",
+    "auto_track_width": true,
+    "hidden_nets": [],
+    "high_contrast_mode": 0,
+    "net_color_mode": 1,
+    "opacity": {
+      "pads": 1.0,
+      "tracks": 1.0,
+      "vias": 1.0,
+      "zones": 0.6
+    },
+    "ratsnest_display_mode": 0,
+    "selection_filter": {
+      "dimensions": true,
+      "footprints": true,
+      "graphics": true,
+      "keepouts": true,
+      "lockedItems": true,
+      "otherItems": true,
+      "pads": true,
+      "text": true,
+      "tracks": true,
+      "vias": true,
+      "zones": true
+    },
+    "visible_items": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25,
+      26,
+      27,
+      28,
+      29,
+      30,
+      32,
+      33,
+      34,
+      35,
+      36
+    ],
+    "visible_layers": "fffffff_ffffffff",
+    "zone_display_mode": 0
+  },
+  "meta": {
+    "filename": "IC_2_SN74LS139.kicad_prl",
+    "version": 3
+  },
+  "project": {
+    "files": []
+  }
+}

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.kicad_pro
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.kicad_pro
@@ -1,0 +1,298 @@
+{
+  "board": {
+    "layer_presets": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_label_syntax": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "extra_units": "error",
+      "global_label_dangling": "warning",
+      "hier_label_mismatch": "error",
+      "label_dangling": "error",
+      "lib_symbol_issues": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "similar_labels": "warning",
+      "unannotated": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "IC_2_SN74LS139.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12.0,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.25,
+        "via_diameter": 0.8,
+        "via_drill": 0.4,
+        "wire_width": 6.0
+      }
+    ],
+    "meta": {
+      "version": 2
+    },
+    "net_colors": null
+  },
+  "pcbnew": {
+    "last_paths": {
+      "gencad": "",
+      "idf": "",
+      "netlist": "",
+      "specctra_dsn": "",
+      "step": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "drawing": {
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "net_format_name": "",
+    "ngspice": {
+      "fix_include_paths": true,
+      "fix_passive_vals": false,
+      "meta": {
+        "version": 0
+      },
+      "model_mode": 0,
+      "workbook_filename": ""
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "spice_adjust_passive_values": false,
+    "spice_external_command": "spice \"%I\"",
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0
+  },
+  "sheets": [],
+  "text_variables": {}
+}

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_2_SN74LS139/IC_2_SN74LS139.proj
@@ -1,0 +1,1 @@
+schematicFile IC_2_SN74LS139.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_3_MM74HC133/IC_3_MM74HC133.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_3_MM74HC133/IC_3_MM74HC133.proj
@@ -1,0 +1,1 @@
+schematicFile IC_3_MM74HC133.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_4_SNx4HC10/IC_4_SNx4HC10.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_4_SNx4HC10/IC_4_SNx4HC10.proj
@@ -1,0 +1,1 @@
+schematicFile IC_3_SNx4HC10.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_5_74HCT280/IC_5_74HCT280.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_5_74HCT280/IC_5_74HCT280.proj
@@ -1,0 +1,1 @@
+schematicFile IC_5_74HCT280.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_6_SNX4HC86/IC_6_SNX4HC86.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_6_SNX4HC86/IC_6_SNX4HC86.proj
@@ -1,0 +1,1 @@
+schematicFile IC_6_SNX4HC86.kicad_sch

--- a/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_7_HD74HC51/IC_7_HD74HC51.proj
+++ b/library/SubcircuitLibrary/Digambar_Wagholikar_ICs/IC_7_HD74HC51/IC_7_HD74HC51.proj
@@ -1,0 +1,1 @@
+schematicFile IC_7_HD74HC51.kicad_sch


### PR DESCRIPTION
### Related Issues
The designed ICs are widely used in digital electronics and form 
the backbone of practical applications.

### Purpose
To provide ready-to-use subcircuit files for the following ICs in eSim:
- SN74HC158 (Multiplexer)
- SN74LS139 (Decoder)
- MM74HC133 (13 Input NAND Gate)
- SNx4HC10 (Triple 3-Input NAND)
- 74HCT280 (Parity Generator)
- SNX4HC86 (XOR Gate)
- HD74HC51 (AND-OR-INVERT Gate)

### Approach
For each IC, the schematic was designed in eSim using KiCad. 
ERC was performed to check for errors. The netlist was generated 
and converted from KiCad to NgSpice format with component values 
assigned. Input/output waveforms were verified against the truth 
table for functional correctness.