### PR TITLE
Fixes issue #417 - Open .kicad_sch subcircuit schematics in Edit Subcircuit

### DIFF
--- a/src/subcircuit/newSub.py
+++ b/src/subcircuit/newSub.py
@@ -54,7 +54,8 @@ class NewSub(QtWidgets.QWidget):
                 os.mkdir(self.schematic_path)
                 self.schematic = os.path.join(
                     self.schematic_path, self.create_schematic)
-                self.cmd = "eeschema " + self.schematic + ".sch"
+                # New KiCad v6 file extension
+                self.cmd = "eeschema " + self.schematic + ".kicad_sch"
                 self.obj_workThread = Worker.WorkerThread(self.cmd)
                 self.obj_workThread.start()
                 self.close()

--- a/src/subcircuit/openSub.py
+++ b/src/subcircuit/openSub.py
@@ -34,6 +34,12 @@ class openSub(QtWidgets.QWidget):
 
             self.schname = os.path.basename(self.editfile)
             self.editfile = os.path.join(self.editfile, self.schname)
-            self.cmd = "eeschema " + self.editfile + ".sch "
+
+            schematic_file = self.editfile + ".kicad_sch"  # kicad6 file
+            if not os.path.exists(schematic_file) and os.path.exists(
+                    self.editfile + ".sch"):
+                schematic_file = self.editfile + ".sch"    # kicad4 file
+
+            self.cmd = "eeschema " + schematic_file
             self.obj_workThread = WorkerThread(self.cmd)
             self.obj_workThread.start()


### PR DESCRIPTION
 Fixes #417
  
   problem: In eSim 2.5, KiCad 6 saves subcircuit schematics as .kicad_sch, but "Edit Subcircuit" always launches eeschema with a hardcoded .sch path. Since that file doesn't exist, eeschema keeps prompting to create a new schematic instead of opening the existing one.
  
   Fix:
   - openSub.py — open the .kicad_sch file when it exists, fall back to legacy .sch otherwise (same pattern Kicad.py uses for the main project schematic). The fallback matters because the shipped SubcircuitLibrary still has ~950 legacy .sch files alongside the newer .kicad_sch ones.
   - newSub.py — new subcircuits are now created as .kicad_sch directly, consistent with how newProject.py creates project schematics.
  
  Tested both paths locally: a KiCad 6 subcircuit (e.g. 2x1_mux from the library) now opens correctly, legacy .sch subcircuits still open, and cancelling the folder dialog does nothing as before.