### PR TITLE
Frontend decoupling and such for the eSim tool-manager

### DIFF
--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -3,7 +3,6 @@ import os
 import sys
 import ctypes
 import subprocess
-import platform
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QTableWidget, QTableWidgetItem, QHeaderView, QProgressBar,
@@ -15,12 +14,12 @@ from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QFont
 import logging
 
-PYTHON     = sys.executable
-SYSTEM     = platform.system()
-IS_WINDOWS = SYSTEM == "Windows"
-IS_LINUX   = SYSTEM == "Linux"
+try:
+    from toolManager.constants import IS_WINDOWS, IS_LINUX
+except (ImportError, ValueError):
+    from constants import IS_WINDOWS, IS_LINUX
 
-import os
+PYTHON     = sys.executable
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 if IS_WINDOWS:

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -14,14 +14,17 @@ from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QFont
 
 try:
-    from gui_fixed import ToolManagerGUI
+    from toolManager.gui_fixed import ToolManagerGUI
 except ImportError:
-    pass # Will handle gracefully later if missing
+    from gui_fixed import ToolManagerGUI
 
-# ==================== CONFIG ====================
+try:
+    from toolManager.constants import IS_WINDOWS
+except (ImportError, ValueError):
+    from constants import IS_WINDOWS
+
 BASE_DIR = Path(__file__).resolve().parent
 INFO_JSON = BASE_DIR / "information.json"
-FULL_GUI  = BASE_DIR / "gui_fixed.py"
 PYTHON    = sys.executable
 
 ANALOG_TOOLS  = ["esim", "kicad", "ngspice"]
@@ -54,7 +57,6 @@ def is_admin():
 def relaunch_as_admin():
     script = str(Path(__file__).resolve())
     
-    # Swap to pythonw.exe to suppress the black console window
     python_exe = PYTHON
     if python_exe.lower().endswith("python.exe"):
         pythonw_exe = python_exe[:-10] + "pythonw.exe"
@@ -126,7 +128,6 @@ class InstallWorker(QThread):
         self.finished.emit(success)
 
 
-# ==================== MAIN WINDOW ====================
 class ToolManagerWindow(QMainWindow):
     def __init__(self):
         super().__init__()
@@ -396,7 +397,6 @@ class ToolManagerWindow(QMainWindow):
         layout.setContentsMargins(30, 30, 30, 30)
         layout.setSpacing(16)
 
-        # Warning banner
         warn = QFrame()
         warn.setStyleSheet("""
             QFrame {
@@ -656,7 +656,7 @@ class ToolManagerWindow(QMainWindow):
                 subprocess.Popen(
                     [PYTHON, backend, "uninstall", tool, "none"],
                     creationflags=(subprocess.CREATE_NO_WINDOW
-                                   if sys.platform == "win32" else 0)
+                                   if IS_WINDOWS else 0)
                 )
             QMessageBox.information(
                 self, "Uninstall Started",
@@ -669,9 +669,7 @@ class ToolManagerWindow(QMainWindow):
 
 
 def main():
-    if sys.platform == "win32" and not is_admin():
-        # Note: We deliberately skip a manual PyQt consent dialog here because
-        # Windows will natively prompt the user with a UAC shield anyway.
+    if IS_WINDOWS and not is_admin():
         relaunch_as_admin()
         sys.exit(0)
 

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -23,12 +23,17 @@ try:
 except (ImportError, ValueError):
     from constants import IS_WINDOWS
 
+try:
+    from toolManager.registry import CATEGORIES
+except (ImportError, ValueError):
+    from registry import CATEGORIES
+
 BASE_DIR = Path(__file__).resolve().parent
 INFO_JSON = BASE_DIR / "information.json"
 PYTHON    = sys.executable
 
-ANALOG_TOOLS  = ["esim", "kicad", "ngspice"]
-DIGITAL_TOOLS = ["esim", "kicad", "ngspice", "ghdl", "verilator", "llvm"]
+ANALOG_TOOLS  = CATEGORIES["analog"]
+DIGITAL_TOOLS = CATEGORIES["digital"]
 
 TOOL_LABELS = {
     "esim":      "eSim",

--- a/src/toolManager/qt/gui_fixed.py
+++ b/src/toolManager/qt/gui_fixed.py
@@ -1,0 +1,9 @@
+from toolManager.gui_fixed import ToolManagerGUI, UninstallWindow, CommandWorker
+from toolManager.registry import TOOLS
+from toolManager.constants import IS_WINDOWS, IS_LINUX
+from toolManager.paths import get_toolmanager_root
+
+__all__ = [
+    "ToolManagerGUI", "UninstallWindow", "CommandWorker",
+    "TOOLS", "IS_WINDOWS", "IS_LINUX", "get_toolmanager_root",
+]

--- a/src/toolManager/qt/main.py
+++ b/src/toolManager/qt/main.py
@@ -1,0 +1,49 @@
+from toolManager.main import ToolManagerWindow, main
+from toolManager.registry import TOOLS, CATEGORIES
+from toolManager.constants import IS_WINDOWS
+from toolManager.qt.gui_fixed import ToolManagerGUI
+
+ANALOG_TOOLS = CATEGORIES["analog"]
+DIGITAL_TOOLS = CATEGORIES["digital"]
+TOOL_LABELS = {tid: spec.label for tid, spec in TOOLS.items()
+                if tid in CATEGORIES["analog"] or tid in CATEGORIES["digital"]}
+TOOL_VERSIONS = {
+    "esim": "2.4",
+    "kicad": "latest",
+    "ngspice": "latest",
+    "ghdl": "latest",
+    "verilator": "latest",
+    "llvm": "latest",
+}
+
+try:
+    from toolManager.platform_utils import is_admin, relaunch_as_admin
+except ImportError:
+    import ctypes
+    import os
+    import sys
+
+    def is_admin():
+        if IS_WINDOWS:
+            try:
+                return ctypes.windll.shell32.IsUserAnAdmin()
+            except Exception:
+                return False
+        return True
+
+    def relaunch_as_admin():
+        script = sys.argv[0]
+        python_exe = sys.executable
+        if python_exe.lower().endswith("python.exe"):
+            pythonw_exe = python_exe[:-10] + "pythonw.exe"
+            if os.path.exists(pythonw_exe):
+                python_exe = pythonw_exe
+        ctypes.windll.shell32.ShellExecuteW(
+            None, "runas", python_exe, f'"{script}"', None, 1
+        )
+
+__all__ = [
+    "ToolManagerWindow", "main", "ToolManagerGUI",
+    "TOOL_LABELS", "TOOL_VERSIONS", "ANALOG_TOOLS", "DIGITAL_TOOLS",
+    "IS_WINDOWS", "is_admin", "relaunch_as_admin",
+]

--- a/src/toolManager/qt/updater_gui.py
+++ b/src/toolManager/qt/updater_gui.py
@@ -1,0 +1,4 @@
+from toolManager.updater_gui import PackageUpdaterWindow, main
+from toolManager.registry import TOOLS
+
+__all__ = ["PackageUpdaterWindow", "main", "TOOLS"]

--- a/src/toolManager/qt/worker.py
+++ b/src/toolManager/qt/worker.py
@@ -1,0 +1,61 @@
+from PyQt6.QtCore import QThread, pyqtSignal
+import subprocess
+import sys
+
+try:
+    from toolManager.worker import BaseWorker, CommandWorker, InstallWorker, InstallerThread
+except ImportError:
+    from toolManager.gui_fixed import CommandWorker
+    from toolManager.updater_gui import InstallerThread
+
+    class BaseWorker(QThread):
+        def cancel(self):
+            pass
+
+    try:
+        from toolManager.worker import InstallWorker
+    except ImportError:
+        from pathlib import Path
+        from toolManager.registry import TOOLS
+
+        BASE_DIR = Path(__file__).resolve().parent.parent
+        PYTHON = sys.executable
+
+        class InstallWorker(QThread):
+            progress = pyqtSignal(str)
+            finished = pyqtSignal(bool)
+
+            def __init__(self, tools):
+                super().__init__()
+                self.tools = tools
+
+            def run(self):
+                success = True
+                backend = str(BASE_DIR / "tool_manager_windows.py")
+                for tool, version in self.tools:
+                    label = TOOLS[tool].label if tool in TOOLS else tool
+                    self.progress.emit(f"Installing {label} {version}...")
+                    try:
+                        proc = subprocess.Popen(
+                            [PYTHON, backend, "install", tool, version],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            text=True,
+                            encoding="utf-8",
+                            errors="ignore",
+                        )
+                        for line in proc.stdout:
+                            line = line.rstrip()
+                            if line:
+                                self.progress.emit(f"  {line}")
+                                if "[ERROR]" in line or "install_failed|" in line:
+                                    success = False
+                        proc.wait()
+                        if proc.returncode != 0:
+                            success = False
+                    except Exception as e:
+                        self.progress.emit(f"  [ERROR] {tool}: {e}")
+                        success = False
+                self.finished.emit(success)
+
+__all__ = ["BaseWorker", "CommandWorker", "InstallWorker", "InstallerThread"]


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose
Frontend decoupling for toolManager — extract Qt UI components into a dedicated qt/ subpackage, refactor platform detection and tool lists to use centralized constants and registry, and add try/except-guarded adapter files for cross-branch compatibility.

### Approach
- Phase 1 — Adapter package (qt/): Create __init__.py, worker.py, gui_fixed.py, main.py, updater_gui.py that re-export the canonical classes and constants from the existing modules. All imports use try/except fallbacks to remain compatible regardless of which module layout is active.
- Phase 2 — Refactoring: 
- gui_fixed.py: Replace inline platform.system() / IS_WINDOWS / IS_LINUX with imports from toolManager.constants (with fallback).
- main.py: Fix ToolManagerGUI import order (try package path first); replace sys.platform == "win32" with IS_WINDOWS from constants; remove dead FULL_GUI variable; derive ANALOG_TOOLS/DIGITAL_TOOLS lists from registry.CATEGORIES instead of hardcoded values.
- Cleanup: Remove stale section headers and inline comments from main.py.
- 7 atomic commits — each leaves the codebase in a working, importable state.