### PR TITLE
refactor

### DIFF
--- a/src/toolManager/gui_fixed.py
+++ b/src/toolManager/gui_fixed.py
@@ -16,20 +16,20 @@ from PyQt6.QtGui import QFont
 import logging
 
 PYTHON     = sys.executable
-SYSTEM     = platform.system()
-IS_WINDOWS = SYSTEM == "Windows"
-IS_LINUX   = SYSTEM == "Linux"
+from pathlib import Path
+from constants import IS_WINDOWS, IS_LINUX
+from paths import get_toolmanager_root
 
-import os
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_DIR = get_toolmanager_root()
 
 if IS_WINDOWS:
-    BACKEND = os.path.join(BASE_DIR, "tool_manager_windows.py")
+    BACKEND = BASE_DIR / "tool_manager_windows.py"
 elif IS_LINUX:
-    BACKEND = os.path.join(BASE_DIR, "tool_manager_linux.py")
+    BACKEND = BASE_DIR / "tool_manager_linux.py"
 else:
-    BACKEND = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tool_manager_windows.py")
+    BACKEND = BASE_DIR / "tool_manager_windows.py"
 
+BACKEND = str(BACKEND)
 TOOLS = {
     "esim": {
         "versions": ["latest", "2.4", "2.3", "2.2"],

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -18,6 +18,21 @@ try:
 except ImportError:
     pass # Will handle gracefully later if missing
 
+try:
+    from registry import (
+        get_tool_label,
+        get_tool_versions,
+        get_default_version,
+        get_supported_tools,
+    )
+except ImportError:
+    from .registry import (
+        get_tool_label,
+        get_tool_versions,
+        get_default_version,
+        get_supported_tools,
+    )
+
 # ==================== CONFIG ====================
 from paths import (
     get_toolmanager_root,
@@ -31,24 +46,7 @@ PYTHON    = sys.executable
 
 ANALOG_TOOLS  = ["esim", "kicad", "ngspice"]
 DIGITAL_TOOLS = ["esim", "kicad", "ngspice", "ghdl", "verilator", "llvm"]
-
-TOOL_LABELS = {
-    "esim":      "eSim",
-    "kicad":     "KiCad",
-    "ngspice":   "Ngspice",
-    "ghdl":      "GHDL",
-    "verilator": "Verilator",
-    "llvm":      "LLVM",
-}
-
-TOOL_VERSIONS = {
-    "esim":      "2.4",
-    "kicad":     "latest",
-    "ngspice":   "latest",
-    "ghdl":      "latest",
-    "verilator": "latest",
-    "llvm":      "latest",
-}
+VISIBLE_TOOLS = [tool for tool in get_supported_tools() if tool in DIGITAL_TOOLS]
 
 def is_admin():
     try:
@@ -71,7 +69,7 @@ def relaunch_as_admin():
     )
 
 def load_installed_versions():
-    versions = {k: "Not installed" for k in TOOL_LABELS}
+    versions = {k: "Not installed" for k in VISIBLE_TOOLS}
     try:
         if INFO_JSON.exists():
             with open(INFO_JSON) as f:
@@ -105,7 +103,7 @@ class InstallWorker(QThread):
         backend = str(BASE_DIR / "tool_manager_windows.py")
         for tool, version in self.tools:
             self.progress.emit(
-                f"Installing {TOOL_LABELS.get(tool, tool)} {version}..."
+                f"Installing {get_tool_label(tool)} {version}..."
             )
             try:
                 proc = subprocess.Popen(
@@ -224,7 +222,8 @@ class ToolManagerWindow(QMainWindow):
         lbl.setStyleSheet("color: #666; background: transparent;")
         layout.addWidget(lbl)
 
-        for key, label in TOOL_LABELS.items():
+        for key in VISIBLE_TOOLS:
+            label = get_tool_label(key)
             ver = self.installed_versions.get(key, "Not installed")
             if ver != "Not installed":
                 text = (f"<span style='color:#28a745;'>●</span> {label} "
@@ -483,7 +482,7 @@ class ToolManagerWindow(QMainWindow):
         title.setStyleSheet("color: #0056b3; margin-bottom: 5px;")
         layout.addWidget(title)        
 
-        info_text = """
+        info_text = f"""
         <div style='font-family: "Segoe UI", sans-serif; font-size: 10.5pt; color: #333; line-height: 1.5;'>
             <p><b>Key Features:</b><br>
             <span style='color: #555;'>• Install analog or digital simulation packages<br>
@@ -491,9 +490,10 @@ class ToolManagerWindow(QMainWindow):
             • Uninstall packages selectively and Integrated with eSim GUI</span></p>
             
             <p><b>Supported Packages:</b><br>
-            <span style='color: #555;'>• KiCad: 6.0.11, 7.0.11, 8.0.9<br>
-            • Ngspice: 35, 36, 37, 38, 39, 40, 41, 42, 43<br>
-            • GHDL: 3.0.0, 4.0.0, 4.1.0, nightly and Verilator: 4.228, 5.020, 5.026, 5.030</span></p>
+            <span style='color: #555;'>• KiCad: {", ".join(get_tool_versions("kicad"))}<br>
+            • Ngspice: {", ".join(get_tool_versions("ngspice"))}<br>
+            • GHDL: {", ".join(get_tool_versions("ghdl"))}<br>
+            • Verilator: {", ".join(get_tool_versions("verilator"))}</span></p>
         </div>
         """
         
@@ -549,7 +549,7 @@ class ToolManagerWindow(QMainWindow):
         )
         if reply == QMessageBox.StandardButton.Yes:
             self._run_install(
-                [(t, TOOL_VERSIONS[t]) for t in ANALOG_TOOLS],
+                [(t, get_default_version(t)) for t in ANALOG_TOOLS],
                 "Analog Mode"
             )
 
@@ -566,7 +566,7 @@ class ToolManagerWindow(QMainWindow):
         )
         if reply == QMessageBox.StandardButton.Yes:
             self._run_install(
-                [(t, TOOL_VERSIONS[t]) for t in DIGITAL_TOOLS],
+                [(t, get_default_version(t)) for t in DIGITAL_TOOLS],
                 "Digital Mode"
             )
 

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -19,9 +19,14 @@ except ImportError:
     pass # Will handle gracefully later if missing
 
 # ==================== CONFIG ====================
-BASE_DIR = Path(__file__).resolve().parent
-INFO_JSON = BASE_DIR / "information.json"
-FULL_GUI  = BASE_DIR / "gui_fixed.py"
+from paths import (
+    get_toolmanager_root,
+    get_install_state_path,
+)
+
+BASE_DIR = get_toolmanager_root()
+INFO_JSON = get_install_state_path()
+FULL_GUI = BASE_DIR / "gui_fixed.py"
 PYTHON    = sys.executable
 
 ANALOG_TOOLS  = ["esim", "kicad", "ngspice"]

--- a/src/toolManager/main.py
+++ b/src/toolManager/main.py
@@ -34,10 +34,16 @@ except ImportError:
     )
 
 # ==================== CONFIG ====================
-from paths import (
-    get_toolmanager_root,
-    get_install_state_path,
-)
+try:
+    from paths import (
+        get_toolmanager_root,
+        get_install_state_path,
+    )
+except ImportError:
+    from .paths import (
+        get_toolmanager_root,
+        get_install_state_path,
+    )
 
 BASE_DIR = get_toolmanager_root()
 INFO_JSON = get_install_state_path()

--- a/src/toolManager/registry.py
+++ b/src/toolManager/registry.py
@@ -110,6 +110,24 @@ def get_supported_tools() -> List[str]:
     return list(TOOLS.keys())
 
 
+def get_tool_label(tool_id: str) -> str:
+    """Return the display label for a tool."""
+    tool = get_tool_metadata(tool_id)
+    return tool.label if tool else tool_id
+
+
+def get_tool_versions(tool_id: str) -> List[str]:
+    """Return supported versions for a tool."""
+    tool = get_tool_metadata(tool_id)
+    return tool.versions if tool else []
+
+
+def get_default_version(tool_id: str) -> str:
+    """Return the default version for a tool."""
+    tool = get_tool_metadata(tool_id)
+    return tool.default_version if tool else "latest"
+
+
 def is_tool_supported(tool_id: str) -> bool:
     """Checks if a tool is supported by the registry."""
     return tool_id in TOOLS

--- a/src/toolManager/tool_manager_windows.py
+++ b/src/toolManager/tool_manager_windows.py
@@ -25,7 +25,7 @@ from utils import (
     WIN_NGSPICE_PATHS, WIN_LLVM_PATHS, get_msys2_bash, 
     get_msys2_mingw_bin, get_msys2_mingw_root
 )
-
+MSYS2_PATH = DEFAULT_MSYS2_PATH
 if sys.platform == "win32":
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='ignore')
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='ignore')
@@ -34,7 +34,7 @@ BASE_DIR = Path(__file__).resolve().parent
 STATE_FILE = BASE_DIR / "information.json"
 BASE_DIR.mkdir(parents=True, exist_ok=True)
 
-MSYS2_PATH = DEFAULT_MSYS2_PATH
+
 
 DOWNLOAD_DIR = BASE_DIR / "Download"
 DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/toolManager/updater_gui.py
+++ b/src/toolManager/updater_gui.py
@@ -12,6 +12,11 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QFont
 
+try:
+    from registry import get_tool_metadata, get_tool_versions
+except ImportError:
+    from .registry import get_tool_metadata, get_tool_versions
+
 class InstallerThread(QThread):
     progress = pyqtSignal(str, int)
     log_output = pyqtSignal(str)  # NEW: For terminal output
@@ -97,13 +102,11 @@ class PackageUpdaterWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.installed_versions = {}
-        
-        self.available_versions = {
-            'KiCad': ['6.0.11', '7.0.11', '8.0.9'],
-            'Ngspice': ['35', '36', '37', '38', '39', '40', '41', '42', '43'],  # ALL VERSIONS!
-            'GHDL': ['3.0.0', '4.0.0', '4.1.0', 'nightly'],
-            'Verilator': ['4.228', '5.020', '5.026', '5.030']
-        }
+        self.available_versions = {}
+        for tool_id in ('kicad', 'ngspice', 'ghdl', 'verilator'):
+            metadata = get_tool_metadata(tool_id)
+            if metadata:
+                self.available_versions[metadata.label] = get_tool_versions(tool_id)
         self.script_mapping = {
             'KiCad': 'update-kicad-final.sh',
             'Ngspice': 'nghdl/update-ngspice-final.sh',  # Correct path!


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

Remove duplicated tool label and version metadata from the Tool Manager UI code and make the existing registry the single source of truth for tool names, supported versions, and default install versions

### Approach

[registry.py] now exposes small helper functions for label, version, and default-version lookup. [main.py] no longer keeps separate hardcoded label/version maps; it reads tool names and install defaults from the registry, and the About tab now renders supported versions directly from registry data. [updater_gui.py] now builds its available-version list from the registry instead of maintaining a second hardcoded copy, while keeping the existing script mapping unchanged.
